### PR TITLE
Custom domain config: CNAME + url + baseurl + stale link sweep

### DIFF
--- a/research/mindmap.md
+++ b/research/mindmap.md
@@ -82,7 +82,7 @@ A living map of **what we know** (with sources) and **what we need to investigat
 
 ### Thematic structure *(merged via PR #3)*
 - The 1955 catalog does **not** present a canonical numbered list of sections. Scholarly reconstructions differ: UNESCO Memory of the World register gives "32 themes" (confirmed). A "37 themes" figure is reported on CNA Luxembourg's education portal but is **not yet independently verified** in this repo (CNA site was unreachable during the 2026-04-19 audit).
-- **Our working reconstruction: 11 thematic clusters** (`sec-prologue` through `sec-rededication-future`) are live on the site under [/sections/](https://danlex.github.io/thefamilyofman/sections/). Each row in `data/sections.csv` is tagged "thematic cluster reconstructed" to avoid implying canonical status.
+- **Our working reconstruction: 11 thematic clusters** (`sec-prologue` through `sec-rededication-future`) are live on the site under [/sections/](https://thefamilyofman.alexandrudan.com/sections/). Each row in `data/sections.csv` is tagged "thematic cluster reconstructed" to avoid implying canonical status.
 - **Governance note:** PR #3 was merged before the four-judge panel ran. The content should be re-audited — especially Judge-Grounding on the Barthes verbatim quotes and Judge-Bias on the theme-count treatment.
 
 ### Catalog — first rows seeded (PR #4 open)

--- a/site/CNAME
+++ b/site/CNAME
@@ -1,0 +1,1 @@
+thefamilyofman.alexandrudan.com

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -5,8 +5,8 @@ description: >-
   503 photographs by 273 photographers, permanently housed at Clervaux
   Castle, Luxembourg (UNESCO Memory of the World, 2003).
 
-url: https://danlex.github.io
-baseurl: /thefamilyofman
+url: https://thefamilyofman.alexandrudan.com
+baseurl: ""
 repository: danlex/thefamilyofman
 edit_url_base: https://github.com/danlex/thefamilyofman/edit/main
 

--- a/site/mindmap.md
+++ b/site/mindmap.md
@@ -100,7 +100,7 @@ A living map of **what we know** (with sources) and **what we need to investigat
 
 ### Thematic structure *(merged via PR #3)*
 - The 1955 catalog does **not** present a canonical numbered list of sections. Scholarly reconstructions differ: UNESCO Memory of the World register gives "32 themes" (confirmed). A "37 themes" figure is reported on CNA Luxembourg's education portal but is **not yet independently verified** in this repo (CNA site was unreachable during the 2026-04-19 audit).
-- **Our working reconstruction: 11 thematic clusters** (`sec-prologue` through `sec-rededication-future`) are live on the site under [/sections/](https://danlex.github.io/thefamilyofman/sections/). Each row in `data/sections.csv` is tagged "thematic cluster reconstructed" to avoid implying canonical status.
+- **Our working reconstruction: 11 thematic clusters** (`sec-prologue` through `sec-rededication-future`) are live on the site under [/sections/](https://thefamilyofman.alexandrudan.com/sections/). Each row in `data/sections.csv` is tagged "thematic cluster reconstructed" to avoid implying canonical status.
 - **Governance note:** PR #3 was merged before the four-judge panel ran. The content should be re-audited — especially Judge-Grounding on the Barthes verbatim quotes and Judge-Bias on the theme-count treatment.
 
 ### Catalog — first rows seeded (PR #4 open)


### PR DESCRIPTION
Closes #22

## Summary

Domain has been moved to thefamilyofman.alexandrudan.com but two artefacts were left pointing at the old GitHub-Pages URL:

1. **`site/_config.yml`** had `url: https://danlex.github.io` and `baseurl: /thefamilyofman`. The deploy workflow's `actions/configure-pages` step masks the baseurl at build time, but the Jekyll SEO plugin reads `site.url` directly for canonical, OpenGraph, JSON-LD, and Atom feed self-link tags — those were shipping with the wrong URL inside the page `<head>`. Bad for SEO and link-sharing.
2. **No CNAME file in repo.** Custom-domain config lived only in the GitHub Pages dashboard. Now committed at `site/CNAME` so the domain claim is captured in source control.

Plus a minor sweep: one stale `danlex.github.io/thefamilyofman` link in `research/mindmap.md` body prose, replaced and re-synced into `site/mindmap.md`.

## Test plan

- [x] Built locally via `jekyll/jekyll:4.2.2` Docker image — clean build.
- [x] `grep -r 'danlex.github.io' site/_site/` returns 0 hits.
- [x] Canonical, og:url, feed self-link, JSON-LD all resolve to `https://thefamilyofman.alexandrudan.com`.
- [x] `site/_site/CNAME` exists with correct content.
- [x] Internal links are root-relative (`/steichen/`, `/photographs/`, etc.) — no `/thefamilyofman/` prefix anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)