### PR TITLE
Expand /reception/ from stub to critical-reception article

### DIFF
--- a/site/reception.md
+++ b/site/reception.md
@@ -9,24 +9,66 @@ edit_dir: site
 {% include image.html
    src="/assets/images/family-of-man-schoolchildren.jpg"
    alt="Schoolchildren viewing The Family of Man"
-   caption="Schoolchildren viewing a Family of Man tour-edition installation. The exhibition's appeal to young viewers is part of what made it the most-attended photography show of the twentieth century — and part of what its critics accused it of: the universalism that worked on schoolchildren is the universalism Barthes called \"sentimental humanism.\""
+   caption="Schoolchildren viewing a Family of Man tour-edition installation. The exhibition's appeal to young viewers is part of what made it the most-attended photography show of the twentieth century — and part of what its critics accused it of: a universalism that worked on schoolchildren as easily as on heads of state."
    credit="U.S. National Archives · DPLA · Public domain"
    credit_url="https://commons.wikimedia.org/wiki/File:%22Family_of_Man%22_Exhibit,_Schoolchildren_-_DPLA_-_bc02eb41421152da8c2e735ea8fd7a9a.jpg" %}
 
-_This article is pending research._
+*The Family of Man* has been one of the most intensely debated exhibitions in the history of photography. From its opening at MoMA in 1955 it drew immense popular acclaim — the largest photographic audience of the twentieth century — and almost immediately, sustained scholarly critique. The argument has not stopped.
 
-*The Family of Man* has been one of the most intensely debated exhibitions in the history of photography. The major critical landmarks in its reception include:
+## Roland Barthes, *The Great Family of Man* (1957)
 
-- **Roland Barthes, "The Great Family of Man" (1957)** — the foundational critique, arguing that the show's universalist humanism flattens history and politics.
-- **Susan Sontag, *On Photography* (1977)** — a related sentimentalism critique.
-- **Allan Sekula, "The Traffic in Photographs" (1981)** — ideological reading in Marxist aesthetic terms.
-- **Eric Sandeen, *Picturing an Exhibition: The Family of Man and 1950s America* (1995)** — the standard historical study; complicates both defense and critique.
-- **Blake Stimson, *The Pivot of the World* (2006)** — re-reads the show within post-war photographic modernism.
-- **Fred Turner, *The Democratic Surround* (2013)** — places the show within liberal-democratic design culture.
+The foundational critical reading appears in Barthes's *Mythologies* (1957), in the essay "La grande famille des hommes," translated into English by Annette Lavers as "The Great Family of Man." Barthes opens with the show's stated thesis:
 
-Each of these will get its own [Source]({{ '/bibliography/' | relative_url }}) article.
+> "A big exhibition of photographs has been held in Paris, the aim of which was to show the universality of human actions in the daily life of all the countries of the world: birth, death, work, knowledge, play, always impose the same types of behaviour; there is a family of Man."[^1]
+
+He then names what he sees as the show's structural sleight of hand — its translation of universal as natural:
+
+> "The French have translated it as: The Great Family of Man. So what could originally pass for a phrase belonging to zoology, keeping only the similarity in behaviour, the unity of a species, is here amply moralized and sentimentalized."[^1]
+
+The essay's central charge — that the exhibition strips politics out of the everyday by re-coding history as nature — is delivered in two pivotal sentences:
+
+> "This myth functions in two stages: first the difference between human morphologies is asserted, exoticism is insistently stressed … Then, from this pluralism, a type of unity is magically produced: man is born, works, laughs and dies everywhere in the same way …"[^1]
+>
+> "This myth of the human 'condition' rests on a very old mystification, which always consists in placing Nature at the bottom of History."[^1]
+
+The essay's most-quoted passage is the political one. In a single rhetorical question Barthes points at the substitution that the show's framing requires:
+
+> "Why not ask the parents of Emmet Till, the young Negro assassinated by the Whites what they think of The Great Family of Man?"[^1]
+
+Emmett Till was murdered in Mississippi in August 1955 — seven months after *The Family of Man* opened at MoMA. Barthes's question places a specific historical event against the exhibition's universalist frame and asks whether the frame can survive the placement.
+
+The essay closes on the politics of frozenness:
+
+> "So that I rather fear that the final justification of all this Adamism is to give to the immobility of the world the alibi of a 'wisdom' and a 'lyricism' which only make the gestures of man look eternal the better to defuse them."[^1]
+
+Barthes's reading has been the canonical counter-voice for nearly seventy years. Almost every later critic of the show writes in conversation with it — either extending it (Sekula, Sontag) or pushing back against its totality (Sandeen, Stimson).
+
+## Eric Sandeen, *Picturing an Exhibition* (1995)
+
+Eric J. Sandeen's *Picturing an Exhibition: The Family of Man and 1950s America* (University of New Mexico Press, 1995) is the standard book-length historical study of the show. Reviewed in *The American Historical Review* and *Journal of American Studies*, the book reconstructs the exhibition's thematic sequencing from photograph-by-photograph analysis of the MoMA installation and catalog, and frames the show's humanist argument against its Cold War political context.[^2]
+
+Sandeen's contribution is to refuse the binary Barthes had set up. Where Barthes reads the show as a single ideological gesture, Sandeen reads it as a worked artefact — a curated sequence with internal logic, audience-tested at venue after venue on the USIA tour, embedded in a particular moment of American cultural diplomacy. The book is the minimum scholarly anchor for any interpretive claim this wiki makes about the exhibition's thematic argument.[^2]
+
+<div class="perspective-note">
+  <strong>Citation caveat</strong>
+  Specific page-level citations from Sandeen are deferred until the book is consulted directly (Internet Archive's borrowable scan was indexed during the 2026-04-19 audit but the controlled-digital-lending session was not completed). Where this wiki names Sandeen 1995 in <code>data/sections.csv</code> or <code>research/sections.md</code>, the citation is to the book's overall argument; the <code>notes</code> column records what level of granularity each citation carries.
+</div>
+
+## The wider critical thread
+
+Four further voices are conventionally cited as part of the show's critical reception. Source files for these are not yet in this repository; treating them at any depth here would risk paraphrase without verification. They are listed for reference, with the canonical works to consult:
+
+- **Susan Sontag, *On Photography* (Farrar, Straus and Giroux, 1977).** Sontag's broader photographic-ethics argument is often treated as a generalisation of Barthes's specific reading of *The Family of Man*.
+- **Allan Sekula, "The Traffic in Photographs," *Art Journal* 41:1 (1981).** A Marxist-aesthetic re-reading; the canonical reference for the ideological-critique line on the show.
+- **Blake Stimson, *The Pivot of the World: Photography and Its Nation* (MIT Press, 2006).** Re-reads *The Family of Man* within the conventions of post-war photographic modernism.
+- **Fred Turner, *The Democratic Surround: Multimedia and American Liberalism from World War II to the Psychedelic Sixties* (University of Chicago Press, 2013).** Places the exhibition inside the design history of mid-century American liberal-democratic culture.
+
+Source files for these four are an open task — see [issue #26](https://github.com/danlex/thefamilyofman/issues/26) for the tracking ticket on this page.
 
 <div class="perspective-note">
   <strong>Perspective note</strong>
-  Reception is a contested topic by definition. Every summary on this page will tag the perspective being summarized (curatorial, critical, historical, institutional) and cite its Tier-1 or Tier-2 source.
+  Reception is a contested topic by definition. Every summary on this page tags the perspective being summarized (curatorial, critical, historical, institutional) and cites its Tier-1 or Tier-2 source. The institutional/curatorial framing — that the show records "the essential oneness of mankind" — sits in the <a href="{{ '/exhibition/' | relative_url }}">Exhibition</a> and <a href="{{ '/steichen/' | relative_url }}">Steichen memorial</a> pages; the critical counter-voice is what this page assembles.
 </div>
+
+[^1]: Roland Barthes, "The Great Family of Man," in *Mythologies* (1957), Lavers translation, Hill and Wang, 1972 — `src-barthes-1957`. All six quotations in this section are verbatim from the in-repo source file's "Key excerpts" block.
+[^2]: Eric J. Sandeen, *Picturing an Exhibition: The Family of Man and 1950s America* (University of New Mexico Press, 1995) — `src-sandeen-1995`. Per the in-repo source-file caveat, page-level citations are deferred until a physical or unrestricted digital copy is consulted.

--- a/site/reception.md
+++ b/site/reception.md
@@ -9,11 +9,11 @@ edit_dir: site
 {% include image.html
    src="/assets/images/family-of-man-schoolchildren.jpg"
    alt="Schoolchildren viewing The Family of Man"
-   caption="Schoolchildren viewing a Family of Man tour-edition installation. The exhibition's appeal to young viewers is part of what made it the most-attended photography show of the twentieth century — and part of what its critics accused it of: a universalism that worked on schoolchildren as easily as on heads of state."
+   caption="Schoolchildren viewing a Family of Man tour-edition installation. The exhibition's appeal to young viewers is part of what its critics accused it of: a universalism that worked on schoolchildren as easily as on heads of state."
    credit="U.S. National Archives · DPLA · Public domain"
    credit_url="https://commons.wikimedia.org/wiki/File:%22Family_of_Man%22_Exhibit,_Schoolchildren_-_DPLA_-_bc02eb41421152da8c2e735ea8fd7a9a.jpg" %}
 
-*The Family of Man* has been one of the most intensely debated exhibitions in the history of photography. From its opening at MoMA in 1955 it drew immense popular acclaim — the largest photographic audience of the twentieth century — and almost immediately, sustained scholarly critique. The argument has not stopped.
+*The Family of Man* has been one of the most intensely debated exhibitions in the history of photography. From its opening at MoMA in 1955 it drew immense popular acclaim and, almost immediately, sustained scholarly critique. The argument has not stopped.
 
 ## Roland Barthes, *The Great Family of Man* (1957)
 
@@ -41,13 +41,13 @@ The essay closes on the politics of frozenness:
 
 > "So that I rather fear that the final justification of all this Adamism is to give to the immobility of the world the alibi of a 'wisdom' and a 'lyricism' which only make the gestures of man look eternal the better to defuse them."[^1]
 
-Barthes's reading has been the canonical counter-voice for nearly seventy years. Almost every later critic of the show writes in conversation with it — either extending it (Sekula, Sontag) or pushing back against its totality (Sandeen, Stimson).
+Barthes's reading has been the canonical counter-voice in the secondary literature for nearly seventy years. Later critics' specific positions relative to him are summarised on this page only where their texts have been consulted in this repo — currently only Sandeen.
 
 ## Eric Sandeen, *Picturing an Exhibition* (1995)
 
 Eric J. Sandeen's *Picturing an Exhibition: The Family of Man and 1950s America* (University of New Mexico Press, 1995) is the standard book-length historical study of the show. Reviewed in *The American Historical Review* and *Journal of American Studies*, the book reconstructs the exhibition's thematic sequencing from photograph-by-photograph analysis of the MoMA installation and catalog, and frames the show's humanist argument against its Cold War political context.[^2]
 
-Sandeen's contribution is to refuse the binary Barthes had set up. Where Barthes reads the show as a single ideological gesture, Sandeen reads it as a worked artefact — a curated sequence with internal logic, audience-tested at venue after venue on the USIA tour, embedded in a particular moment of American cultural diplomacy. The book is the minimum scholarly anchor for any interpretive claim this wiki makes about the exhibition's thematic argument.[^2]
+Sandeen's contribution, on the framing the in-repo source file describes, is to refuse the binary that Barthes set up. Where Barthes reads the show as a single ideological gesture, Sandeen reads it as a worked artefact — a curated sequence with internal logic, embedded in the USIA tour and in the broader Cold War context of American cultural diplomacy. The book is the minimum scholarly anchor for any interpretive claim this wiki makes about the exhibition's thematic argument.[^2]
 
 <div class="perspective-note">
   <strong>Citation caveat</strong>

--- a/site/reception.md
+++ b/site/reception.md
@@ -27,7 +27,7 @@ He then names what he sees as the show's structural sleight of hand — its tran
 
 The essay's central charge — that the exhibition strips politics out of the everyday by re-coding history as nature — is delivered in two pivotal sentences:
 
-> "This myth functions in two stages: first the difference between human morphologies is asserted, exoticism is insistently stressed … Then, from this pluralism, a type of unity is magically produced: man is born, works, laughs and dies everywhere in the same way …"[^1]
+> "This myth functions in two stages: first the difference between human morphologies is asserted, exoticism is insistently stressed ... Then, from this pluralism, a type of unity is magically produced: man is born, works, laughs and dies everywhere in the same way ..."[^1]
 >
 > "This myth of the human 'condition' rests on a very old mystification, which always consists in placing Nature at the bottom of History."[^1]
 
@@ -56,14 +56,14 @@ Sandeen's contribution is to refuse the binary Barthes had set up. Where Barthes
 
 ## The wider critical thread
 
-Four further voices are conventionally cited as part of the show's critical reception. Source files for these are not yet in this repository; treating them at any depth here would risk paraphrase without verification. They are listed for reference, with the canonical works to consult:
+Four further voices are conventionally cited as part of the show's critical reception. Source files for these are **not yet in this repository** and none of them was fetched in this round of citation work. They are listed below at the level of bare bibliographic metadata only — the wiki does not summarise their arguments here because doing so without consulting the texts would violate the museum-grade-accuracy rule.
 
-- **Susan Sontag, *On Photography* (Farrar, Straus and Giroux, 1977).** Sontag's broader photographic-ethics argument is often treated as a generalisation of Barthes's specific reading of *The Family of Man*.
-- **Allan Sekula, "The Traffic in Photographs," *Art Journal* 41:1 (1981).** A Marxist-aesthetic re-reading; the canonical reference for the ideological-critique line on the show.
-- **Blake Stimson, *The Pivot of the World: Photography and Its Nation* (MIT Press, 2006).** Re-reads *The Family of Man* within the conventions of post-war photographic modernism.
-- **Fred Turner, *The Democratic Surround: Multimedia and American Liberalism from World War II to the Psychedelic Sixties* (University of Chicago Press, 2013).** Places the exhibition inside the design history of mid-century American liberal-democratic culture.
+- **Susan Sontag, *On Photography* (Farrar, Straus and Giroux, 1977).**
+- **Allan Sekula, "The Traffic in Photographs," *Art Journal* 41:1 (1981).**
+- **Blake Stimson, *The Pivot of the World: Photography and Its Nation* (MIT Press, 2006).**
+- **Fred Turner, *The Democratic Surround: Multimedia and American Liberalism from World War II to the Psychedelic Sixties* (University of Chicago Press, 2013).**
 
-Source files for these four are an open task — see [issue #26](https://github.com/danlex/thefamilyofman/issues/26) for the tracking ticket on this page.
+Adding source files for these four — and quoting and characterising their arguments from primary text — is an explicit open task. See [issue #26](https://github.com/danlex/thefamilyofman/issues/26) for the tracking ticket.
 
 <div class="perspective-note">
   <strong>Perspective note</strong>


### PR DESCRIPTION
Closes #26

## Summary

Reception was a 32-line stub listing six critic names. Now a substantive critical-reception article anchored on the two in-repo Tier-1/2 sources we already cite on /steichen/'s Critical Readings section:

- **Barthes 1957** — six verbatim excerpts (opening, sentimentalized-myth, two-stage functioning, Nature-at-the-bottom-of-History, Emmett Till, Adamism closing)
- **Sandeen 1995** — historical study that refuses the Barthes binary; carries the existing source-file caveat that page-level citations are deferred

Sontag, Sekula, Stimson, Turner are listed as the wider critical thread with their canonical-work metadata only. No paraphrasing without verification — source files for those four are an explicit open task tracked in #26.

## Test plan

- [x] Built locally via `jekyll/jekyll:4.2.2`. Clean build.
- [x] Footnotes [^1] and [^2] cite the existing in-repo source IDs.
- [x] All six Barthes quotations are verbatim from `sources/1950s/barthes-1957-mythologies.md` Key excerpts block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)