### PR TITLE
Add real search across photographs, photographers, sources

### DIFF
--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -10,5 +10,9 @@
       <a href="{{ '/bibliography/' | relative_url }}">Sources</a>
       <a href="{{ '/about/' | relative_url }}">About</a>
     </nav>
+    <div class="site-search">
+      <input id="site-search" type="search" placeholder="Search the wiki…" aria-label="Search" autocomplete="off">
+      <div id="site-search-results" class="search-results" hidden></div>
+    </div>
   </div>
 </header>

--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-baseurl="{{ site.baseurl }}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -20,5 +20,6 @@
   </main>
   {% include footer.html %}
 </div>
+<script src="{{ '/assets/js/search.js' | relative_url }}" defer></script>
 </body>
 </html>

--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -1783,6 +1783,91 @@ main {
   .page-toc ol { columns: 1; }
 }
 
+/* ---------- Site search (header) ---------- */
+
+.site-search {
+  position: relative;
+  flex: 1 1 220px;
+  max-width: 320px;
+  margin-left: 1rem;
+}
+.site-search input[type="search"] {
+  width: 100%;
+  font-family: var(--sans);
+  font-size: 0.85rem;
+  padding: 0.4rem 0.7rem;
+  border: 1px solid var(--hairline);
+  background: var(--paper);
+  color: var(--ink);
+  border-radius: 0;
+  -webkit-appearance: none;
+  appearance: none;
+}
+.site-search input[type="search"]::placeholder { color: var(--mid); }
+.site-search input[type="search"]:focus {
+  outline: 1px solid var(--ink);
+  outline-offset: -1px;
+}
+.search-results {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  max-height: 70vh;
+  overflow-y: auto;
+  background: var(--paper);
+  border: 1px solid var(--ink);
+  z-index: 20;
+  font-family: var(--sans);
+  font-size: 0.88rem;
+}
+.search-hit {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr;
+  grid-template-rows: auto auto;
+  column-gap: 0.75rem;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--hairline);
+  text-decoration: none;
+  color: var(--ink);
+  transition: background 0.1s ease;
+}
+.search-hit:last-child { border-bottom: 0; }
+.search-hit:hover { background: var(--mist); }
+.search-hit-kind {
+  grid-row: 1 / span 2;
+  align-self: center;
+  font-family: var(--mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--mid);
+  border: 1px solid var(--hairline);
+  text-align: center;
+  padding: 0.15rem 0.25rem;
+}
+.search-hit-title {
+  font-family: var(--serif);
+  font-size: 0.95rem;
+  line-height: 1.3;
+}
+.search-hit-sub {
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  color: var(--mid);
+  margin-top: 0.15rem;
+}
+.search-empty {
+  padding: 0.85rem 0.9rem;
+  font-family: var(--sans);
+  font-size: 0.85rem;
+  color: var(--mid);
+}
+@media (max-width: 880px) {
+  .site-search { max-width: none; margin-left: 0; flex-basis: 100%; order: 99; }
+  .search-results { max-height: 50vh; }
+}
+
 /* ---------- Empty state ---------- */
 
 .empty {

--- a/site/assets/js/search.js
+++ b/site/assets/js/search.js
@@ -1,0 +1,98 @@
+// Vanilla client-side search across photographs, photographers, sources, and top-level pages.
+// Loads /search.json once, filters on substring match (lowercased), renders a dropdown of up to 10 results.
+// No dependencies. No tracking. No analytics. Pure DOM.
+
+(function () {
+  var input = document.getElementById('site-search');
+  var results = document.getElementById('site-search-results');
+  if (!input || !results) return;
+
+  var index = null;
+  var indexLoading = false;
+  var indexUrl = (document.documentElement.dataset.baseurl || '') + '/search.json';
+
+  function loadIndex() {
+    if (index || indexLoading) return Promise.resolve(index);
+    indexLoading = true;
+    return fetch(indexUrl)
+      .then(function (r) { return r.ok ? r.json() : []; })
+      .then(function (data) { index = data || []; indexLoading = false; return index; })
+      .catch(function () { index = []; indexLoading = false; return index; });
+  }
+
+  function escapeHTML(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function score(item, q) {
+    // Prefer matches in title, then subtitle, then body. Lower score = better.
+    var t = (item.title || '').toLowerCase();
+    var s = (item.subtitle || '').toLowerCase();
+    var b = (item.body || '').toLowerCase();
+    if (t.indexOf(q) !== -1) return t.indexOf(q);
+    if (s.indexOf(q) !== -1) return 100 + s.indexOf(q);
+    if (b.indexOf(q) !== -1) return 1000 + b.indexOf(q);
+    return -1;
+  }
+
+  function render(query, items) {
+    if (!query) {
+      results.innerHTML = '';
+      results.hidden = true;
+      return;
+    }
+    if (!items.length) {
+      results.innerHTML = '<div class="search-empty">No matches.</div>';
+      results.hidden = false;
+      return;
+    }
+    var html = items.map(function (it) {
+      var kind = it.kind || '';
+      return '<a class="search-hit search-hit-' + escapeHTML(kind) + '" href="' + escapeHTML(it.url) + '">'
+        + '<span class="search-hit-kind">' + escapeHTML(kind) + '</span>'
+        + '<span class="search-hit-title">' + escapeHTML(it.title) + '</span>'
+        + (it.subtitle ? '<span class="search-hit-sub">' + escapeHTML(it.subtitle) + '</span>' : '')
+        + '</a>';
+    }).join('');
+    results.innerHTML = html;
+    results.hidden = false;
+  }
+
+  function filter(q) {
+    if (!index) return [];
+    q = q.toLowerCase();
+    var scored = [];
+    for (var i = 0; i < index.length; i++) {
+      var sc = score(index[i], q);
+      if (sc >= 0) scored.push({ item: index[i], score: sc });
+    }
+    scored.sort(function (a, b) { return a.score - b.score; });
+    return scored.slice(0, 10).map(function (s) { return s.item; });
+  }
+
+  var debounce;
+  input.addEventListener('input', function () {
+    var q = input.value.trim();
+    if (!q) { render('', []); return; }
+    clearTimeout(debounce);
+    debounce = setTimeout(function () {
+      loadIndex().then(function () { render(q, filter(q)); });
+    }, 80);
+  });
+  input.addEventListener('focus', function () { if (!index) loadIndex(); });
+  input.addEventListener('blur', function () {
+    // Slight delay so click on a hit registers before we hide
+    setTimeout(function () { results.hidden = true; }, 150);
+  });
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') { input.blur(); results.hidden = true; }
+    if (e.key === '/' && document.activeElement !== input) {
+      e.preventDefault();
+      input.focus();
+    }
+  });
+})();

--- a/site/search.json
+++ b/site/search.json
@@ -1,0 +1,59 @@
+---
+permalink: /search.json
+layout: null
+---
+[
+{%- assign sep = "" -%}
+
+{%- comment -%} Photographs (from data/photographs.csv) {%- endcomment -%}
+{%- for p in site.data.photographs -%}
+  {{ sep }}
+  {%- assign sec = site.data.sections | where: "id", p.section | first -%}
+  {
+    "kind": "photograph",
+    "id": {{ p.id | jsonify }},
+    "title": {{ p.title | default: "Untitled" | jsonify }},
+    "subtitle": {{ p.photographer | jsonify }},
+    "body": {%- if p.country and p.country != "" -%}{{ p.country | append: " · " | append: sec.title | append: " · " | append: p.year | append: " · " | append: p.notes | jsonify }}{%- else -%}{{ p.notes | jsonify }}{%- endif -%},
+    "url": {{ "/photographs/" | append: p.id | append: "/" | relative_url | jsonify }}
+  }
+  {%- assign sep = "," -%}
+{%- endfor -%}
+
+{%- comment -%} Photographers (from data/photographers.csv) {%- endcomment -%}
+{%- for c in site.data.photographers -%}
+  {{ sep }}
+  {
+    "kind": "photographer",
+    "id": {{ c.id | jsonify }},
+    "title": {{ c.name | jsonify }},
+    "subtitle": {%- if c.birth_year and c.birth_year != "" -%}{{ c.birth_year | append: "–" | append: c.death_year | append: " · " | append: c.nationality | jsonify }}{%- else -%}{{ c.nationality | jsonify }}{%- endif -%},
+    "body": {{ c.notes | jsonify }},
+    "url": {{ "/photographers/" | append: c.id | append: "/" | relative_url | jsonify }}
+  }
+  {%- assign sep = "," -%}
+{%- endfor -%}
+
+{%- comment -%} Sources (from site/_sources/) {%- endcomment -%}
+{%- for s in site.sources -%}
+  {{ sep }}
+  {
+    "kind": "source",
+    "id": {{ s.id | default: s.slug | jsonify }},
+    "title": {{ s.title | jsonify }},
+    "subtitle": {{ s.author | default: "" | append: " · " | append: s.year | append: " · Tier " | append: s.tier | jsonify }},
+    "body": {{ s.content | strip_html | strip_newlines | truncate: 400 | jsonify }},
+    "url": {{ s.url | relative_url | jsonify }}
+  }
+  {%- assign sep = "," -%}
+{%- endfor -%}
+
+{%- comment -%} Top-level pages {%- endcomment -%}
+,{ "kind": "page", "id": "exhibition", "title": "The 1955 Exhibition", "subtitle": "Overview", "body": "Edward Steichen Paul Rudolph Carl Sandburg MoMA opening 24 January 1955", "url": {{ "/exhibition/" | relative_url | jsonify }} }
+,{ "kind": "page", "id": "steichen", "title": "Edward Steichen", "subtitle": "Curator · 1879–1973", "body": "Bivange Luxembourg Photo-Secession Stieglitz 291 Gallery Morgan Pond Moonlight Vogue Vanity Fair Naval Aviation Photographic Unit MoMA Charlotte 1963 Joanna Taub", "url": {{ "/steichen/" | relative_url | jsonify }} }
+,{ "kind": "page", "id": "clervaux", "title": "Clervaux", "subtitle": "Permanent home since 1994", "body": "Centre national de l'audiovisuel CNA Luxembourg castle restoration 2010 2013", "url": {{ "/clervaux/" | relative_url | jsonify }} }
+,{ "kind": "page", "id": "tour", "title": "World Tour", "subtitle": "1955–1962 USIA", "body": "United States Information Agency 91 venues 9 million visitors", "url": {{ "/tour/" | relative_url | jsonify }} }
+,{ "kind": "page", "id": "unesco", "title": "UNESCO Memory of the World", "subtitle": "Inscription 2003", "body": "documentary heritage", "url": {{ "/unesco/" | relative_url | jsonify }} }
+,{ "kind": "page", "id": "reception", "title": "Reception", "subtitle": "Critical readings", "body": "Barthes Sandeen Sontag Sekula Stimson Turner mythologies", "url": {{ "/reception/" | relative_url | jsonify }} }
+,{ "kind": "page", "id": "sections", "title": "Thematic sections", "subtitle": "Eleven clusters", "body": "Prologue Lovers Marriage Family Children Play Work Eating Relationships Hardship Death Rededication", "url": {{ "/sections/" | relative_url | jsonify }} }
+]


### PR DESCRIPTION
Closes #36

## Summary

Static client-side search across the wiki. No museum-content claims; the index ships text that's already in committed data/source files.

- **`site/search.json`** (Liquid → JSON) — 278 items: 217 photographs + 20 photographers + 34 sources + 7 page entries.
- **`site/assets/js/search.js`** — vanilla, ~80 lines, no deps. Lazy-loads index on first focus, three-tier score (title > subtitle > body), top-10 dropdown, 80ms debounce. `Esc` closes; `/` focuses from anywhere.
- **Header search input** added to every page via `site/_includes/header.html`.
- **`data-baseurl` on `<html>`** so the search URL works on both custom-domain and GitHub-Pages base-path deployments.
- **CSS** for input + dropdown + per-hit chips, monochrome editorial vocabulary.

## Test plan

- [x] Built locally via `jekyll/jekyll:4.2.2`. Clean build.
- [x] /search.json renders with 278 items.
- [x] Sample query "lange" returns 5 photograph hits.
- [x] Search input present on every page.
- [ ] Live verification post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)