### PR TITLE
Search UX: icon-toggle drawer instead of inline input

### DIFF
--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -10,9 +10,30 @@
       <a href="{{ '/bibliography/' | relative_url }}">Sources</a>
       <a href="{{ '/about/' | relative_url }}">About</a>
     </nav>
-    <div class="site-search">
-      <input id="site-search" type="search" placeholder="Search the wiki…" aria-label="Search" autocomplete="off">
+    <button id="site-search-toggle" class="site-search-toggle" aria-label="Open search" aria-expanded="false" aria-controls="site-search-drawer" type="button">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <circle cx="11" cy="11" r="7"></circle>
+        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+      </svg>
+    </button>
+  </div>
+  <div id="site-search-drawer" class="site-search-drawer" hidden>
+    <div class="wrap-wide site-search-drawer-inner">
+      <div class="site-search-field">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="11" cy="11" r="7"></circle>
+          <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+        </svg>
+        <input id="site-search" type="search" placeholder="Search photographs, photographers, sources…" aria-label="Search" autocomplete="off">
+        <button id="site-search-close" class="site-search-close" aria-label="Close search" type="button">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
+          </svg>
+        </button>
+      </div>
       <div id="site-search-results" class="search-results" hidden></div>
+      <p class="site-search-hint">Press <kbd>/</kbd> from anywhere to focus the search · <kbd>Esc</kbd> to close.</p>
     </div>
   </div>
 </header>

--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -1783,41 +1783,101 @@ main {
   .page-toc ol { columns: 1; }
 }
 
-/* ---------- Site search (header) ---------- */
+/* ---------- Site search (icon-toggle drawer) ---------- */
 
-.site-search {
-  position: relative;
-  flex: 1 1 220px;
-  max-width: 320px;
-  margin-left: 1rem;
+.site-search-toggle {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 0.35rem 0.5rem;
+  margin-left: 0.5rem;
+  color: var(--mid);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: color 0.12s ease, background 0.12s ease;
 }
-.site-search input[type="search"] {
-  width: 100%;
-  font-family: var(--sans);
-  font-size: 0.85rem;
-  padding: 0.4rem 0.7rem;
-  border: 1px solid var(--hairline);
-  background: var(--paper);
+.site-search-toggle:hover,
+.site-search-toggle[aria-expanded="true"] {
   color: var(--ink);
-  border-radius: 0;
+  background: var(--mist);
+}
+.site-search-toggle svg { display: block; }
+
+.site-search-drawer {
+  border-top: 1px solid var(--hairline);
+  border-bottom: 1px solid var(--ink);
+  background: var(--paper);
+  animation: site-search-slide 0.16s ease-out both;
+}
+@keyframes site-search-slide {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.site-search-drawer-inner {
+  padding: 1.25rem 1.25rem 1.5rem;
+}
+.site-search-field {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  border-bottom: 1px solid var(--ink);
+  padding: 0.5rem 0;
+}
+.site-search-field svg { color: var(--mid); flex-shrink: 0; }
+.site-search-field input[type="search"] {
+  flex: 1 1 auto;
+  border: 0;
+  background: transparent;
+  font-family: var(--serif);
+  font-size: clamp(1.1rem, 2.2vw, 1.45rem);
+  color: var(--ink);
+  padding: 0.25rem 0;
   -webkit-appearance: none;
   appearance: none;
 }
-.site-search input[type="search"]::placeholder { color: var(--mid); }
-.site-search input[type="search"]:focus {
-  outline: 1px solid var(--ink);
-  outline-offset: -1px;
+.site-search-field input[type="search"]::placeholder { color: var(--mid); }
+.site-search-field input[type="search"]:focus { outline: none; }
+.site-search-close {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 0.3rem 0.4rem;
+  color: var(--mid);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
 }
+.site-search-close:hover { color: var(--ink); background: var(--mist); }
+.site-search-hint {
+  margin: 0.6rem 0 0;
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  color: var(--mid);
+  letter-spacing: 0.02em;
+}
+.site-search-hint kbd {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  border: 1px solid var(--hairline);
+  border-radius: 3px;
+  padding: 0.05rem 0.3rem;
+  background: var(--mist);
+  color: var(--ink);
+}
+
 .search-results {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
-  right: 0;
-  max-height: 70vh;
+  position: static;
+  max-height: 60vh;
   overflow-y: auto;
-  background: var(--paper);
-  border: 1px solid var(--ink);
-  z-index: 20;
+  background: transparent;
+  border: 0;
+  margin-top: 0.75rem;
   font-family: var(--sans);
   font-size: 0.88rem;
 }
@@ -1826,7 +1886,7 @@ main {
   grid-template-columns: 5.5rem 1fr;
   grid-template-rows: auto auto;
   column-gap: 0.75rem;
-  padding: 0.6rem 0.8rem;
+  padding: 0.65rem 0.5rem;
   border-bottom: 1px solid var(--hairline);
   text-decoration: none;
   color: var(--ink);
@@ -1844,11 +1904,11 @@ main {
   color: var(--mid);
   border: 1px solid var(--hairline);
   text-align: center;
-  padding: 0.15rem 0.25rem;
+  padding: 0.2rem 0.25rem;
 }
 .search-hit-title {
   font-family: var(--serif);
-  font-size: 0.95rem;
+  font-size: 1rem;
   line-height: 1.3;
 }
 .search-hit-sub {
@@ -1858,14 +1918,19 @@ main {
   margin-top: 0.15rem;
 }
 .search-empty {
-  padding: 0.85rem 0.9rem;
+  padding: 1rem 0.5rem;
   font-family: var(--sans);
-  font-size: 0.85rem;
+  font-size: 0.88rem;
   color: var(--mid);
 }
-@media (max-width: 880px) {
-  .site-search { max-width: none; margin-left: 0; flex-basis: 100%; order: 99; }
-  .search-results { max-height: 50vh; }
+
+body.site-search-open {
+  /* prevent header scroll-shifts when drawer mounts */
+  overflow: hidden;
+}
+@media (max-width: 540px) {
+  .site-search-field input[type="search"] { font-size: 1.05rem; }
+  .search-hit { grid-template-columns: 4.5rem 1fr; column-gap: 0.5rem; }
 }
 
 /* ---------- Empty state ---------- */

--- a/site/assets/js/search.js
+++ b/site/assets/js/search.js
@@ -1,11 +1,17 @@
-// Vanilla client-side search across photographs, photographers, sources, and top-level pages.
-// Loads /search.json once, filters on substring match (lowercased), renders a dropdown of up to 10 results.
-// No dependencies. No tracking. No analytics. Pure DOM.
+// Vanilla client-side search with Apple-style icon-toggle drawer.
+// - Magnifying-glass button in header → drawer slides down below nav with input + results
+// - Lazy-loads /search.json on first open, caches in memory
+// - Substring matching with three-tier score (title > subtitle > body), top 10
+// - "/" focuses (when drawer closed → opens it). Esc closes. Click outside closes.
+// No dependencies. No tracking.
 
 (function () {
+  var toggle = document.getElementById('site-search-toggle');
+  var drawer = document.getElementById('site-search-drawer');
   var input = document.getElementById('site-search');
   var results = document.getElementById('site-search-results');
-  if (!input || !results) return;
+  var closeBtn = document.getElementById('site-search-close');
+  if (!toggle || !drawer || !input || !results) return;
 
   var index = null;
   var indexLoading = false;
@@ -22,14 +28,10 @@
 
   function escapeHTML(s) {
     return String(s == null ? '' : s)
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
   }
 
   function score(item, q) {
-    // Prefer matches in title, then subtitle, then body. Lower score = better.
     var t = (item.title || '').toLowerCase();
     var s = (item.subtitle || '').toLowerCase();
     var b = (item.body || '').toLowerCase();
@@ -39,12 +41,20 @@
     return -1;
   }
 
-  function render(query, items) {
-    if (!query) {
-      results.innerHTML = '';
-      results.hidden = true;
-      return;
+  function filter(q) {
+    if (!index) return [];
+    q = q.toLowerCase();
+    var scored = [];
+    for (var i = 0; i < index.length; i++) {
+      var sc = score(index[i], q);
+      if (sc >= 0) scored.push({ item: index[i], score: sc });
     }
+    scored.sort(function (a, b) { return a.score - b.score; });
+    return scored.slice(0, 10).map(function (x) { return x.item; });
+  }
+
+  function render(query, items) {
+    if (!query) { results.innerHTML = ''; results.hidden = true; return; }
     if (!items.length) {
       results.innerHTML = '<div class="search-empty">No matches.</div>';
       results.hidden = false;
@@ -62,17 +72,25 @@
     results.hidden = false;
   }
 
-  function filter(q) {
-    if (!index) return [];
-    q = q.toLowerCase();
-    var scored = [];
-    for (var i = 0; i < index.length; i++) {
-      var sc = score(index[i], q);
-      if (sc >= 0) scored.push({ item: index[i], score: sc });
-    }
-    scored.sort(function (a, b) { return a.score - b.score; });
-    return scored.slice(0, 10).map(function (s) { return s.item; });
+  function openDrawer() {
+    drawer.hidden = false;
+    document.body.classList.add('site-search-open');
+    toggle.setAttribute('aria-expanded', 'true');
+    setTimeout(function () { input.focus(); input.select(); }, 30);
+    if (!index) loadIndex();
   }
+  function closeDrawer() {
+    drawer.hidden = true;
+    document.body.classList.remove('site-search-open');
+    toggle.setAttribute('aria-expanded', 'false');
+    input.value = '';
+    render('', []);
+    toggle.focus();
+  }
+  function isOpen() { return !drawer.hidden; }
+
+  toggle.addEventListener('click', function () { isOpen() ? closeDrawer() : openDrawer(); });
+  if (closeBtn) closeBtn.addEventListener('click', closeDrawer);
 
   var debounce;
   input.addEventListener('input', function () {
@@ -83,16 +101,21 @@
       loadIndex().then(function () { render(q, filter(q)); });
     }, 80);
   });
-  input.addEventListener('focus', function () { if (!index) loadIndex(); });
-  input.addEventListener('blur', function () {
-    // Slight delay so click on a hit registers before we hide
-    setTimeout(function () { results.hidden = true; }, 150);
-  });
+
   document.addEventListener('keydown', function (e) {
-    if (e.key === 'Escape') { input.blur(); results.hidden = true; }
+    if (e.key === 'Escape' && isOpen()) { e.preventDefault(); closeDrawer(); return; }
     if (e.key === '/' && document.activeElement !== input) {
+      // Don't hijack typing in other input fields
+      var t = e.target;
+      if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
       e.preventDefault();
-      input.focus();
+      if (!isOpen()) openDrawer(); else input.focus();
     }
+  });
+
+  document.addEventListener('click', function (e) {
+    if (!isOpen()) return;
+    if (drawer.contains(e.target) || toggle.contains(e.target)) return;
+    closeDrawer();
   });
 })();


### PR DESCRIPTION
Closes #38

## Summary

Replaces the inline search input (PR #37) with an Apple-style icon-toggle drawer:

- Magnifying-glass button in the nav (a11y-compliant: aria-label / aria-expanded / aria-controls).
- Click → full-width drawer slides down below the header with a large serif input + close button + keyboard-shortcut hint.
- Auto-focus when opening.
- Closes on Esc, click outside, close button, or pressing the icon again.
- '/' shortcut still works — opens the drawer if closed, focuses input if already open. Suppressed when typing in another input.

CSS replaces the inline-search block; results dropdown is now embedded inline within the drawer.

No content / source changes.

## Test plan

- [x] Built locally via `jekyll/jekyll:4.2.2`. Clean build.
- [x] Toggle button + drawer markup present on every page.
- [x] Old inline input markup removed.
- [ ] Live click-test post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)