### PR TITLE
Expand /clervaux/ from stub to substantive overview

### DIFF
--- a/research/clervaux.md
+++ b/research/clervaux.md
@@ -1,0 +1,106 @@
+---
+title: "The Luxembourg chapter: donation, storage, Clervaux Castle, restoration"
+status: draft
+last_updated: 2026-04-29
+perspective: [institutional, curatorial]
+contested: false
+sources:
+  - src-cna-collections-deu-family-of-man
+  - src-cna-collections-eng-family-of-man
+  - src-cna-education
+  - src-cna-edu-steichen-bio
+  - src-chronicle-lu-2025-cercle-cite-steichen
+  - src-unesco-mow-2003
+  - src-sandeen-1995
+fresh_fetches_this_round:
+  - "https://steichencollections-cna.lu/eng/collections/1_the-family-of-man (2026-04-29) — primary new source for this note"
+  - "https://www.thefamilyofman.education/en/historical-context/the-family-of-man-the-book-of-humanity (2026-04-29) — re-fetched, no Clervaux-specific content surfaced beyond what was already captured in src-cna-education"
+  - "https://www.thefamilyofman.education/en/the-family-of-man-an-exhibition-with-international-aura (2026-04-29) — returned HTTP 404"
+  - "https://steichencollections-cna.lu/eng/about/the-cna (2026-04-29) — returned HTTP 404"
+---
+
+# The Luxembourg chapter: donation, storage, Clervaux Castle, restoration
+
+## Scope and provenance note
+
+This note traces the Luxembourg chapter of *The Family of Man*: how the original prints came to Luxembourg from the United States, what happened to them between donation and the 1994 permanent installation at Clervaux Castle, the inauguration of that installation, the 2010–2013 restoration campaign, and the institutional structure under which the collection sits today. The narrative is built mainly from the Centre national de l'audiovisuel's (CNA) own collections-website pages — the German-language page `src-cna-collections-deu-family-of-man` (carried from earlier rounds) and the English-language page `src-cna-collections-eng-family-of-man` (newly fetched 2026-04-29). Two facts that remain unanchored to a Tier-1 source — the 1963 White House meeting between Steichen and Grand Duchess Charlotte, and the "ideal place" remark Steichen is reported to have made at Clervaux — are carried only on the Tier-3 Cercle Cité lecture summary `src-chronicle-lu-2025-cercle-cite-steichen` and are flagged as such in their respective sections.
+
+A perspective caveat: this is a Luxembourgian institutional history, told by the institution that owns the prints. Scholarly counter-readings of the Clervaux installation's curatorial choices (re-hang, design, narrative framing) have not been catalogued in this repo's secondary literature so far; what follows is therefore mostly the CNA's own framing.
+
+## 1. Tour end and the 1964 donation
+
+The CNA's published chronology dates the donation of the prints to Luxembourg to the period **1964–1966** and attributes it to the United States Government rather than to Steichen personally — although it preserves Steichen's role as the agent who asked for the gift to be made. The English page reads: "the US Government donates the last complete version of the travelling exhibition to Luxembourg" (`src-cna-collections-eng-family-of-man`). The German page is more explicit about Steichen's request: "Die amerikanische Regierung schenkt Luxemburg auf Wunsch Edward Steichens die letzte vollständige Version der Wanderausstellung" — *the American government donates to Luxembourg, at Edward Steichen's request, the last complete version of the touring exhibition* (`src-cna-collections-deu-family-of-man`).
+
+Two structural points follow from how the CNA pages frame this. First, what arrived in Luxembourg was a *touring set* — one of the United States Information Agency–era circulating versions, described as "the last complete version" — not the original 1955 MoMA installation. The 1955 prints at MoMA itself were a separate holding, and the relationship between the touring versions and the MoMA mother-set is a matter neither CNA page elaborates here; this is a documented research gap that would require U.S. archival sources (USIA records or the MoMA exhibition file) to resolve and was not pursued in this round. Second, the CNA pages describe Luxembourg as the recipient at state level (the U.S. government to Luxembourg), not specifically as a personal gift from Steichen to a private institution.
+
+A persistent secondary tradition — reported in the Cercle Cité lecture summary on chronicle.lu (`src-chronicle-lu-2025-cercle-cite-steichen`) — places the diplomatic ground-laying for this gift at a 1963 Washington state visit, during which "the Luxembourg-born photographer met Grand Duchess Charlotte during a state visit to Washington in 1963, where he introduced himself by stating: 'I am a Luxembourgish boy.'" The same source reports that Steichen's request "led to the US government's donation of *The Family of Man* exhibition to Luxembourg in 1964." This 1963 meeting is **not corroborated by either CNA page consulted in this round**; it rests on a Tier-3 Luxembourg-press article reporting on a public lecture, with no primary archival reference (Cour grand-ducale or U.S. State Department records) cited. The narrative is therefore plausible and widely-circulated but not currently anchored to a Tier-1 source. Verification against the Cour grand-ducale archive or the diplomatic-record series is a documented open task for a future pass.
+
+## 2. The storage and partial-display years, 1964–1994
+
+The longest and most opaque period in the Luxembourg chapter is the three decades between donation and permanent installation. The CNA's published chronology fills a portion — but not all — of that gap. Its English page records, as a single chronological entry: "**1974–1989** — Partial exhibition of the photographs at Clervaux Castle" (`src-cna-collections-eng-family-of-man`). The German collections page's recorded excerpts in this repo do not contain a parallel 1974–1989 entry; whether the German page in fact also carries the partial-display line was not re-verified in this round, and the claim therefore rests on the English page alone. What the English page attests is that, from 1974 through 1989, *a selection* of the prints was on view at Clervaux Castle — neither the full set nor a permanent canonical installation, but a partial display.
+
+What the CNA pages consulted in this round do *not* attest:
+
+- Where the prints were physically held between 1964 and 1974. Neither CNA page consulted describes a storage location, conservator-of-record, or intermediate venue for that decade. This is a known gap.
+- What "partial" meant in 1974–1989: how many prints were shown, in which rooms of Clervaux Castle, under what curatorial framing, with what installation design, or by whom. None of these specifics is attested on the pages fetched this round.
+- Why the 1974–1989 period ended, and what then happened to the prints between 1989 and the 1994 permanent installation. The CNA chronology jumps from the close of the partial-display period directly to "1994 — Establishment of the collection as a permanent exhibition." The five intervening years are unaccounted for in the pages consulted here.
+
+Within this storage and partial-display period sits the 1966 Steichen Clervaux visit. The CNA English page records, in its 1964–1966 frame: "Edward Steichen visits his native country and expresses his wish for 'The Family of Man' to be exhibited permanently at Clervaux Castle" (`src-cna-collections-eng-family-of-man`). This is a Tier-1 institutional attestation that Steichen visited Luxembourg in this period and articulated a wish for permanent installation at Clervaux specifically. The Tier-3 chronicle.lu lecture summary supplies a more colourful formulation: "In 1966, Edward Steichen was then honoured in Luxembourg and visited Clervaux, where he reportedly stated that this was the ideal place for the exhibition to reside" (`src-chronicle-lu-2025-cercle-cite-steichen`). The "ideal place" wording is **not** present in the CNA pages fetched this round, and the chronicle.lu account itself flags it as second-hand ("he reportedly stated"). The CNA's wording — "expresses his wish" — should be preferred where a single phrasing must be chosen.
+
+The thirty-year storage and partial-display period is therefore a known, partially-filled gap. A future pass could productively consult: (a) Luxembourg cultural-affairs ministry archives for any 1964–1974 custodianship or storage record; (b) *Luxemburger Wort* and *Tageblatt* coverage of the 1974 partial-display opening, which on the CNA chronology must have been a public event; (c) the CNA's own annual reports or institutional histories. None of these were consulted in this round.
+
+## 3. The 1994 permanent installation at Clervaux Castle
+
+The CNA's chronology dates the establishment of the permanent installation to 1994 — without giving an exact day or month on either of the two collections pages fetched this round. The English page records the year-line as: "**1994** — Establishment of the collection as a permanent exhibition at Clervaux Castle" (`src-cna-collections-eng-family-of-man`). The German page's parallel: "Präsentation der Sammlung als Dauerausstellung im Schloss von Clervaux" (`src-cna-collections-deu-family-of-man`).
+
+Material that the in-repo sources *do not* attest, and that should not be claimed without further fetches:
+
+- **The exact 1994 inauguration date** is not given on either CNA page consulted this round. Contemporary reporting in *Luxemburger Wort* or *Tageblatt* would carry it but was not fetched.
+- **The 1994 curator-of-record** is not named on either page. The two CNA pages describe institutional custodianship by the CNA but do not name a specific 1994 curator. The Cercle Cité lecture summary (`src-chronicle-lu-2025-cercle-cite-steichen`) does not address this either. No name should be attached to the 1994 inauguration without a fresh primary source.
+- **The 1994 installation design** — print placement, room layout, lighting, signage — is not described on the pages fetched. The "very sober architecture conceived by designer Nathalie Jacoby (NJOY)" attested by the CNA English page is, in context, the design of the rooms as *re-installed* after the 2010–2013 restoration, not the 1994 layout (see §4 below). It would be a confabulation to read Jacoby's design back into 1994.
+
+The exhibition's physical home — Clervaux Castle, a hilltop fortification in northern Luxembourg — lies outside the scope of this note in its non–*Family of Man* dimensions; for the present project, what matters is that from 1994 onward the prints have an institutionally-permanent address.
+
+## 4. The 2010–2013 restoration
+
+The second restoration phase is the most concretely-documented episode in the Luxembourg chapter, because the CNA's English collections page names both the conservation team and the architectural designer of the rebuilt rooms. The German page (`src-cna-collections-deu-family-of-man`) records the campaign in the form: "Eine zweite Restaurierungsphase wurde in den Jahren 2010-2013 unternommen" — *a second restoration phase was undertaken in 2010–2013*. (The reference to a *second* phase implies a first, earlier phase whose date and scope are not specified on either page consulted; tracing the first restoration is a separate research task.)
+
+The English page supplies the dated bookends and the team names:
+
+- "**September 2010** — Closure of the exhibition for renovation purposes."
+- "**July 2013** — Reopening following renovation of exhibition rooms and restoration of photographs."
+- "The restoration campaign has been led in collaboration with the Studio Berselli from Milan, Italy (Silvia Berselli, Roberta Piantavigna, Francesca Vantellini, Isabel Dimas)."
+- "the exhibition rooms featuring a very sober architecture conceived by designer Nathalie Jacoby (NJOY)."
+
+(All four quotations: `src-cna-collections-eng-family-of-man`.)
+
+Two distinguishable sub-projects sit under the umbrella label "2010–2013 restoration": (i) **physical restoration of the photographs**, led by Studio Berselli, Milan, with the four named conservators (Silvia Berselli, Roberta Piantavigna, Francesca Vantellini, Isabel Dimas); and (ii) **renovation and re-architecting of the exhibition rooms** at Clervaux Castle, designed by Nathalie Jacoby (NJOY), described on the CNA page as a "very sober architecture." The CNA page does not break out which conservator handled which subset of the prints, nor specify which conservation treatments were applied; nor does it describe the curatorial decisions that may have accompanied the re-hang. A more technical write-up — likely in CNA annual reports or in the Studio Berselli professional record — would be required to characterise the conservation methodology in detail; that was not consulted in this round.
+
+The 2010–2013 reopening matters not just as a conservation event but as the moment that fixed the *current* Clervaux experience. The installation a visitor encounters today is the post-2013 re-installation in Jacoby's rooms, on Berselli-restored prints — not a continuous continuation of the 1994 hang.
+
+## 5. Current curation by the CNA
+
+The Centre national de l'audiovisuel — Luxembourg's national audiovisual archive — is the institutional custodian of the Clervaux collection. Its custodial role is the through-line that links donation, storage, partial display, permanent installation, and restoration: in the framing the CNA itself adopts, *The Family of Man* is part of the Steichen Collections, alongside Steichen's own photographic archive (`src-cna-edu-steichen-bio`, `src-cna-collections-deu-family-of-man`). The institution publishes two complementary public-facing properties relevant to this note: the collections-website `steichencollections-cna.lu` (multilingual, cited above as `src-cna-collections-deu-family-of-man` and `src-cna-collections-eng-family-of-man`), and the educational portal `thefamilyofman.education` (cited as `src-cna-education` and `src-cna-edu-steichen-bio`).
+
+The CNA's framing of the exhibition is, by design, the framing the museum visitor encounters at Clervaux: a humanist photo-essay across "37 themes like a photo-essay about human development and cycles of life" (`src-cna-education`). This count differs from UNESCO's "32 themes" (`src-unesco-mow-2003`) — a discrepancy the repo records in `research/sections.md` and does not relitigate here. What matters for the Luxembourg chapter is that the institutional voice the visitor meets at Clervaux is continuous with — and inherits — Steichen's own curatorial argument. Counter-readings of that argument are best-known from Roland Barthes's *Mythologies* (1957) on the Paris stop and Eric Sandeen's *Picturing an Exhibition* (1995) on the 1955 American context (`src-sandeen-1995`); neither has been catalogued in this repo as engaging the Clervaux re-installation specifically.
+
+## 6. UNESCO 2003 inscription
+
+In 2003, *The Family of Man* was inscribed on UNESCO's Memory of the World International Register, with the institutional home-of-record listed as Clervaux Castle, Luxembourg, under CNA custodianship (`src-unesco-mow-2003`). This inscription places the Clervaux holding inside an international heritage frame and is the strongest external endorsement of the Luxembourg chapter as a globally-significant cultural-heritage matter. The discrepancy between UNESCO's "32 themes" and the CNA's "37 themes" — discussed above and in `research/sections.md` — should not obscure that the inscription itself names Clervaux as the site of record. For a fuller treatment of what UNESCO inscription does and does not entail, see `/unesco/`.
+
+## 7. Known gaps and open tasks
+
+In rough order of how soluble each gap is from accessible sources:
+
+- **Exact 1994 inauguration date and curator of record.** The CNA collections pages give a year. *Luxemburger Wort* and *Tageblatt* coverage of the inauguration was not fetched in this round; either paper, or a CNA press release of the day, should yield day, month, and the names of curators and ceremonial speakers.
+- **The 1964–1974 storage decade.** Where the prints physically lived between donation and the start of partial display at Clervaux is unattested in any source consulted this round. A Luxembourg cultural-affairs ministry archival pass is the natural next step.
+- **The 1989–1994 transition.** How and why the 1974–1989 partial display ended, and what bridged the five years to permanent installation, is unattested in the CNA pages fetched.
+- **The "first" restoration phase implied by the German page's "second restoration phase" formulation.** Date, scope, conservator are all unattested in this round.
+- **Detailed conservation methodology of the 2010–2013 campaign.** Studio Berselli's published record, and CNA annual reports for the period, were not fetched.
+- **The 1963 Washington Charlotte–Steichen meeting.** Currently rests only on a Tier-3 chronicle.lu lecture summary. Verifiable against Cour grand-ducale or U.S. State Department diplomatic records; not attempted this round.
+- **The "ideal place" attribution for the 1966 Clervaux visit.** Not present in the CNA pages fetched; rests on the Tier-3 chronicle.lu summary, which itself flags the report as second-hand.
+- **The relationship between the touring set donated to Luxembourg and the original 1955 MoMA installation prints.** USIA circulation records and the MoMA exhibition file would be required.
+
+## 8. Citation provenance summary
+
+The narrative above rests on Tier-1 institutional sources fetched directly this round (`src-cna-collections-eng-family-of-man` newly fetched 2026-04-29) and earlier rounds (`src-cna-collections-deu-family-of-man`, `src-cna-education`, `src-cna-edu-steichen-bio`, `src-unesco-mow-2003`). The 1963/1966 personal-narrative thread rests on one Tier-3 source (`src-chronicle-lu-2025-cercle-cite-steichen`) and is flagged in §1 and §2. No Luxembourg ministry archives, no contemporary 1994 press, and no internal CNA conservation reports were consulted in this round — the absence of these is recorded in §7 rather than papered over. The 1990s opening reportage in *Luxemburger Wort* and *Tageblatt* listed in this issue's primary-source brief was *not consulted in this round*; any future expansion that draws on those papers must fetch them rather than carry the citation as given.

--- a/site/clervaux.md
+++ b/site/clervaux.md
@@ -6,8 +6,6 @@ permalink: /clervaux/
 edit_dir: site
 ---
 
-_This article is pending research. A Phase 1 investigation will populate it._
-
 {% include image.html
    src="/assets/images/clervaux-castle.jpg"
    alt="Clervaux Castle, a hilltop stone fortification in northern Luxembourg"
@@ -15,21 +13,35 @@ _This article is pending research. A Phase 1 investigation will populate it._
    credit="Donar Reiskoffer · CC BY-SA 3.0"
    credit_url="https://commons.wikimedia.org/wiki/File:Luxembourg,_Clervaux,_Castle2.JPG" %}
 
-After the world tour concluded, the prints returned to Luxembourg as a gift from Edward Steichen to his country of birth. Since **1994**, the collection has been on permanent display at **Clervaux Castle**, curated by the **Centre national de l'audiovisuel (CNA)**. A major restoration and re-installation was completed between 2010 and 2013.
+<nav class="page-toc" aria-label="Page contents">
+  <div class="kicker">On this page</div>
+  <ol>
+    <li><a href="#the-1964-donation">The 1964 donation</a></li>
+    <li><a href="#the-1966-clervaux-visit">The 1966 Clervaux visit</a></li>
+    <li><a href="#storage-and-partial-display">Storage and partial display</a></li>
+    <li><a href="#the-1994-permanent-installation">The 1994 permanent installation</a></li>
+    <li><a href="#the-2010-2013-restoration">The 2010–2013 restoration</a></li>
+    <li><a href="#under-cna-curation">Under CNA curation</a></li>
+    <li><a href="#unesco-recognition">UNESCO recognition</a></li>
+    <li><a href="#visiting">Visiting</a></li>
+  </ol>
+</nav>
 
-{% include image.html
-   src="/assets/images/clervaux-2013-interior.jpg"
-   alt="Interior view of the Family of Man installation at Clervaux Castle"
-   caption="The installation as it stood in 2013, between the first inauguration (1994) and the second restoration phase (2010–2013)."
-   credit="Gorup de Besanez · CC BY-SA 4.0"
-   credit_url="https://commons.wikimedia.org/wiki/File:Familyofman1.JPG" %}
+After [the world tour]({{ '/tour/' | relative_url }}) concluded, the prints came home to Steichen's country of birth. Since **1994** the collection has been on permanent display at **Clervaux Castle**, in northern Luxembourg, under the curation of the **Centre national de l'audiovisuel (CNA)**. What follows is the chronological story of how it got there, anchored on the CNA's own institutional record.[^1][^2]
 
-{% include image.html
-   src="/assets/images/clervaux-2015-rg72-interior.jpg"
-   alt="Family of Man interior at Clervaux, 2015"
-   caption="A second view of the Clervaux installation, photographed in 2015 — after the 2010–2013 restoration."
-   credit="RG72 · CC BY-SA 4.0"
-   credit_url="https://commons.wikimedia.org/wiki/File:Familio_de_homo_(Clervaux).jpg" %}
+## The 1964 donation
+
+The CNA's published chronology dates the Luxembourg arrival to the period **1964–1966**. The donor of record is the **United States Government** — not Steichen personally — although Steichen is preserved as the agent who asked for the gift to be made. The English collections page records the event in the form: *"the US Government donates the last complete version of the travelling exhibition to Luxembourg."*[^1] The German page is more explicit about Steichen's role: *"Die amerikanische Regierung schenkt Luxemburg auf Wunsch Edward Steichens die letzte vollständige Version der Wanderausstellung"* — *the American government donates to Luxembourg, at Edward Steichen's request, the last complete version of the touring exhibition.*[^2]
+
+Two things follow from this framing. First, what arrived in Luxembourg was a **touring set** — one of the United States Information Agency–era circulating versions, described as *"the last complete version"* — not the original 1955 MoMA installation. The relationship between the touring versions and the MoMA mother-set is a matter the CNA pages do not elaborate; resolving it would require U.S. archival sources (USIA records, the MoMA exhibition file) that have not been fetched. Second, the gift was state-to-state, the U.S. government to Luxembourg.
+
+A persistent secondary tradition places the diplomatic ground-laying for this gift at a **1963 Washington state visit**, during which Steichen is reported to have met Grand Duchess Charlotte and introduced himself with the line *"I am a Luxembourgish boy."*[^3] This narrative is widely circulated in Luxembourg cultural press but currently rests, on this wiki, on a single Tier-3 source — a 2025 *Chronicle.lu* report on a public Cercle Cité lecture, which itself does not cite a primary archival document. The Charlotte–Steichen meeting is not corroborated by either of the two CNA pages consulted in this round; verification against the *Cour grand-ducale* archive or U.S. State Department diplomatic records is a documented open task.
+
+## The 1966 Clervaux visit
+
+Steichen visited his birth country in 1966, two years after the donation, and made his preference for Clervaux Castle as the permanent home explicit. The CNA English page records, in its 1964–1966 frame, *"Edward Steichen visits his native country and expresses his wish for 'The Family of Man' to be exhibited permanently at Clervaux Castle."*[^1]
+
+A more colourful formulation circulates in Luxembourg cultural press — that Steichen *"reportedly stated that this was the ideal place for the exhibition to reside"*[^3] — but the *"ideal place"* wording is not present in either CNA page consulted, and the *Chronicle.lu* account itself flags it as second-hand. Where a single phrasing must be chosen, the CNA's *"expresses his wish"* is the Tier-1 institutional wording and is preferred here.
 
 {% include image.html
    src="/assets/images/clervaux-signage.jpg"
@@ -38,9 +50,74 @@ After the world tour concluded, the prints returned to Luxembourg as a gift from
    credit="Joachim Köhler · CC BY-SA 3.0"
    credit_url="https://commons.wikimedia.org/wiki/File:Clerf-FamilyOfMan-20060908.JPG" %}
 
-In **2003**, the collection was inscribed on **UNESCO's Memory of the World** register — see [UNESCO]({{ '/unesco/' | relative_url }}).
+## Storage and partial display
+
+The longest and most opaque period in the Luxembourg chapter is the three decades between donation and permanent installation. The CNA chronology fills part of that gap: from **1974 to 1989**, *"a partial exhibition of the photographs"* was on view at Clervaux Castle — a selection, not the full set, and not the canonical permanent installation that would follow.[^1]
+
+What the CNA pages consulted in this round do not attest:
+
+- **Where the prints physically lived between 1964 and 1974.** No storage location, conservator-of-record, or intermediate venue is described for that decade. This is a known gap.
+- **What "partial" meant in 1974–1989.** How many prints were shown, in which rooms, under what curatorial framing, with what installation design — none of these specifics is on the pages fetched.
+- **Why the 1974–1989 period ended, and what bridged the five years to 1994.** The chronology jumps from the close of partial display straight to *"1994 — Establishment of the collection as a permanent exhibition."*[^1] The intervening period is unaccounted for.
+
+A future research pass could fill these gaps from a Luxembourg cultural-affairs ministry archival visit, or from contemporary *Luxemburger Wort* and *Tageblatt* coverage of the 1974 partial-display opening — neither of which has been consulted on this wiki yet.
+
+## The 1994 permanent installation
+
+The CNA dates the establishment of the permanent installation to **1994** — a year only, without an exact day or month on either of the two collections pages fetched.[^1][^2] The same pages do not name the curator of record for the inauguration, do not describe the 1994 installation design (print placement, room layout, signage), and do not record speakers or programme for the opening event.
+
+Two things on this wiki are therefore deliberately conservative. We say *"1994"*, not a specific 1994 date. We do not name the 1994 curator. And we do not read the *current* room architecture — which dates from the 2010–2013 restoration described below — back into 1994. Anyone who visited the installation between 1994 and September 2010 saw a different physical layout than the one a visitor sees today.
+
+## The 2010–2013 restoration
+
+The second restoration phase is the most concretely-documented episode in the Luxembourg chapter. The CNA English page supplies dated bookends and team names; the German page summarises the campaign in a single sentence — *"Eine zweite Restaurierungsphase wurde in den Jahren 2010-2013 unternommen"* — *a second restoration phase was undertaken in 2010–2013.*[^2] (The phrasing *"second"* implies an earlier phase; that earlier phase's date and scope are not described on either page consulted.)
+
+The headline facts from the English page:[^1]
+
+- **September 2010** — Closure of the exhibition for renovation.
+- **July 2013** — Reopening following renovation of the exhibition rooms and restoration of the photographs.
+- The conservation campaign was *"led in collaboration with the Studio Berselli from Milan, Italy (Silvia Berselli, Roberta Piantavigna, Francesca Vantellini, Isabel Dimas)."*
+- The renovated rooms feature *"a very sober architecture conceived by designer Nathalie Jacoby (NJOY)."*
+
+Two distinguishable sub-projects sit under the umbrella label "the 2010–2013 restoration": **physical conservation of the photographs**, led by Studio Berselli with the four named conservators, and **renovation of the exhibition rooms**, designed by Nathalie Jacoby (NJOY). The CNA page does not break out which conservator handled which subset of the prints, nor which conservation treatments were applied; characterising the methodology in detail would require Studio Berselli's published record or the CNA's own annual reports, which have not been fetched here.
+
+{% include image.html
+   src="/assets/images/clervaux-2013-interior.jpg"
+   alt="Interior view of the Family of Man installation at Clervaux Castle"
+   caption="The installation as it stood in 2013, photographed shortly after the second restoration phase reopened in July 2013."
+   credit="Gorup de Besanez · CC BY-SA 4.0"
+   credit_url="https://commons.wikimedia.org/wiki/File:Familyofman1.JPG" %}
+
+The reopening matters not just as a conservation event but as the moment that fixed the *current* Clervaux experience. The installation a visitor encounters today is the post-2013 re-installation — Berselli-restored prints in Jacoby's rooms — not a continuous continuation of the 1994 hang.
+
+{% include image.html
+   src="/assets/images/clervaux-2015-rg72-interior.jpg"
+   alt="Family of Man interior at Clervaux, 2015"
+   caption="A second view of the installation, photographed in 2015 — two years after the July 2013 reopening."
+   credit="RG72 · CC BY-SA 4.0"
+   credit_url="https://commons.wikimedia.org/wiki/File:Familio_de_homo_(Clervaux).jpg" %}
+
+## Under CNA curation
+
+The **Centre national de l'audiovisuel** — Luxembourg's national audiovisual archive — is the institutional custodian of the Clervaux collection. Its custodial role is the through-line that links donation, storage, partial display, permanent installation, and restoration. The CNA publishes two complementary public-facing properties relevant to the exhibition: the multilingual collections-website [`steichencollections-cna.lu`](https://steichencollections-cna.lu/eng/collections/1_the-family-of-man) (the source for most of the chronology above) and the educational portal [`thefamilyofman.education`](https://www.thefamilyofman.education/) (which carries the curatorial argument for visitors).
+
+The framing the visitor encounters at Clervaux today is, by design, continuous with — and inherits — Steichen's own argument: a humanist photo-essay across *"37 themes like a photo-essay about human development and cycles of life."*[^4] That *"37 themes"* count differs from UNESCO's *"32 themes"*; we record the discrepancy on the [Sections index]({{ '/sections/' | relative_url }}) and do not relitigate it here.
+
+## UNESCO recognition
+
+In **2003**, *The Family of Man* was inscribed on **UNESCO's Memory of the World International Register**, with the institutional home-of-record listed as Clervaux Castle, Luxembourg, under CNA custodianship.[^5] The inscription places the Clervaux holding inside an international heritage frame and is the strongest external endorsement of the Luxembourg chapter as a globally-significant cultural-heritage matter. For a fuller treatment of what Memory of the World status does and does not entail, see the [UNESCO page]({{ '/unesco/' | relative_url }}).
+
+## Visiting
+
+The collection is on permanent view at Clervaux Castle. Visitor information — opening hours, ticketing, accessibility, school programmes, and the educational portal that accompanies the show — is published by the CNA on [`steichencollections-cna.lu`](https://steichencollections-cna.lu/eng/collections/1_the-family-of-man) and on the dedicated portal [`thefamilyofman.education`](https://www.thefamilyofman.education/). This wiki does not duplicate the CNA's visitor pages; it complements them with the historical, curatorial, and critical record. For Steichen's own life — Bivange, the Naval Aviation Photographic Unit, the 1963 Charlotte meeting — see the [Steichen memorial]({{ '/steichen/' | relative_url }}). For the show's critical reception, see [Reception]({{ '/reception/' | relative_url }}).
 
 <div class="perspective-note">
   <strong>Perspective note</strong>
-  The Luxembourg chapter of the story is largely francophone and germanophone. CNA publications in French and German are primary sources for this article and are not optional.
+  This page is told mostly through the CNA's own institutional voice. The CNA owns the prints and inherits Steichen's framing of the show; that voice is one of three on this wiki, alongside the <a href="{{ '/reception/' | relative_url }}">Reception page</a> (Barthes, Sandeen, and the wider critical thread) and the <a href="{{ '/sections/' | relative_url }}">Sections index</a> (this wiki's working reconstruction of the thematic flow). Where a Tier-1 wording (CNA) and a Tier-3 wording (Cercle Cité lecture summary) diverge — as on the 1966 Clervaux visit — the CNA wording is preferred and the Tier-3 variant is named as such. Several gaps in the Luxembourg chronology — the 1964–1974 storage decade, an exact 1994 inauguration date, the 1994 curator of record, the existence and date of an earlier "first" restoration phase — are documented openly on this page rather than papered over. Full provenance and an open-tasks list are in <a href="https://github.com/danlex/thefamilyofman/blob/main/research/clervaux.md"><code>research/clervaux.md</code></a>.
 </div>
+
+[^1]: Centre national de l'audiovisuel (CNA), Luxembourg. *The Family of Man* (English collections page). [steichencollections-cna.lu/eng/collections/1_the-family-of-man](https://steichencollections-cna.lu/eng/collections/1_the-family-of-man) — fetched 2026-04-29. `src-cna-collections-eng-family-of-man`. Anchors: 1964–1966 donation framing; 1966 Steichen visit and "expresses his wish" wording; 1974–1989 partial display; 1994 permanent installation; September 2010 closure / July 2013 reopening; Studio Berselli, Milan (Silvia Berselli, Roberta Piantavigna, Francesca Vantellini, Isabel Dimas); Nathalie Jacoby (NJOY) "very sober architecture."
+[^2]: Centre national de l'audiovisuel (CNA), Luxembourg. *The Family of Man / Familio de homo* (German collections page). [steichencollections-cna.lu/deu/collections/1_the-family-of-man](https://steichencollections-cna.lu/deu/collections/1_the-family-of-man) — accessed 2026-04-25. `src-cna-collections-deu-family-of-man`. Anchors the German wording of the donation, the 1994 permanent installation, and the *"second restoration phase 2010–2013"* phrasing. The 1974–1989 partial display is attested on the English page only; whether the German page also carries that entry was not re-verified in this round.
+[^3]: JCA, "Cercle Cité Lecture Celebrates Life of Edward Steichen," *Chronicle.lu*, 1 April 2025. `src-chronicle-lu-2025-cercle-cite-steichen`. Tier 3. Carries the 1963 Charlotte / Washington meeting, the *"I am a Luxembourgish boy"* line, and the second-hand *"ideal place"* report for the 1966 Clervaux visit. Not corroborated against a Tier-1 archive in this round; both the 1963 meeting and the *"ideal place"* attribution should be read as plausible Luxembourg-press tradition rather than primary-archival fact.
+[^4]: Centre national de l'audiovisuel (CNA), Luxembourg. "The Family of Man, the book of humanity" (educational portal). `src-cna-education`. The *"37 themes"* count is verbatim from this source; the CNA portal does not publish a canonical numbered list of all 37.
+[^5]: UNESCO. *Family of Man*, Memory of the World International Register, inscribed 2003. `src-unesco-mow-2003`. The *"32 themes"* count differs from the CNA portal's *"37 themes"*; the discrepancy is recorded on this wiki's [Sections index]({{ '/sections/' | relative_url }}) and is not relitigated here.

--- a/sources/2010s/cna-collections-eng-family-of-man.md
+++ b/sources/2010s/cna-collections-eng-family-of-man.md
@@ -1,0 +1,40 @@
+---
+id: src-cna-collections-eng-family-of-man
+title: "The Family of Man — CNA Steichen-Collections (English collections page)"
+author: "Centre national de l'audiovisuel (CNA)"
+year: 2015
+type: website
+publisher: "Centre national de l'audiovisuel, Luxembourg"
+url: "https://steichencollections-cna.lu/eng/collections/1_the-family-of-man"
+accessed: 2026-04-29
+tier: 1
+language: en
+verified: true
+tags: [cna, clervaux, donation-1964, restoration-2010-2013, family-of-man]
+---
+
+## Citation
+
+Centre national de l'audiovisuel (CNA), Luxembourg. *The Family of Man* (English-language collections page). https://steichencollections-cna.lu/eng/collections/1_the-family-of-man — accessed 2026-04-29.
+
+## Relevance
+
+The English-language counterpart to the CNA's German collections page (`src-cna-collections-deu-family-of-man`). Anchors the Luxembourg-chapter chronology more granularly than the German page: it dates the partial-display period at Clervaux to **1974–1989**, the permanent installation to **1994**, and gives **September 2010 → July 2013** as the bookends of the second restoration phase. It also names the conservation team (Studio Berselli, Milan — Silvia Berselli, Roberta Piantavigna, Francesca Vantellini, Isabel Dimas) and the architectural designer of the renovated rooms (Nathalie Jacoby / NJOY). These specifics are not present on the German page or on the CNA education portal.
+
+## Key excerpts / pages
+
+- "**1964–1966** — the US Government donates the last complete version of the travelling exhibition to Luxembourg. Edward Steichen visits his native country and expresses his wish for 'The Family of Man' to be exhibited permanently at Clervaux Castle."
+- "**1974–1989** — Partial exhibition of the photographs at Clervaux Castle."
+- "**1994** — Establishment of the collection as a permanent exhibition at Clervaux Castle."
+- "**September 2010** — Closure of the exhibition for renovation purposes."
+- "**July 2013** — Reopening following renovation of exhibition rooms and restoration of photographs."
+- "The restoration campaign has been led in collaboration with the Studio Berselli from Milan, Italy (Silvia Berselli, Roberta Piantavigna, Francesca Vantellini, Isabel Dimas)."
+- "the exhibition rooms featuring a very sober architecture conceived by designer Nathalie Jacoby (NJOY)."
+
+## Notes
+
+- Fetched 2026-04-29 directly. Companion to `src-cna-collections-deu-family-of-man` (German page), `src-cna-education` (English education portal), and `src-cna-edu-steichen-bio` (Steichen biographical page on the same education portal). The four CNA pages reproduce the same institutional voice across languages and contexts.
+- Perspective: institutional / curatorial (CNA inherits Steichen's framing).
+- Wording on Steichen's 1966 wish — "expresses his wish for 'The Family of Man' to be exhibited permanently at Clervaux Castle" — is more conservative than the Tier-3 chronicle.lu lecture summary's "this was the ideal place for the exhibition to reside." Where the two diverge, prefer the CNA wording.
+- The page does not name the 1994 curator of record nor give a specific inauguration date in 1994; those gaps are recorded in `research/clervaux.md` §3 and §7.
+- The phrase "second restoration phase" on the German page implies an earlier (first) restoration phase; the English page does not address that earlier phase either, so its date and scope remain unattested in either page consulted this round.


### PR DESCRIPTION
Closes #42.

## Summary

- Rewrites `site/clervaux.md` (~2,100 words, 8 sections + TOC + footnoted citations + perspective note). All four pre-existing images preserved.
- Adds `research/clervaux.md` (~2,500 words) with explicit gaps inventory (§7).
- Adds source entry `sources/2010s/cna-collections-eng-family-of-man.md` for the freshly-fetched English CNA collections page (https://steichencollections-cna.lu/eng/collections/1_the-family-of-man, fetched 2026-04-29). Tier 1, `verified: true`.

## Anchors

- 1964–1966 donation framing (US Government → Luxembourg, at Steichen's request) — `src-cna-collections-eng-family-of-man` + `src-cna-collections-deu-family-of-man`
- 1966 Steichen visit, "expresses his wish" wording — `src-cna-collections-eng-family-of-man`
- 1974–1989 partial display at Clervaux — `src-cna-collections-eng-family-of-man` (English page only; German source's recorded excerpts do not contain that line, flagged in [^2])
- 1994 permanent installation (year only, no day/month) — both CNA pages
- September 2010 → July 2013 second restoration; Studio Berselli, Milan team (4 named conservators); Nathalie Jacoby (NJOY) rooms — `src-cna-collections-eng-family-of-man`
- 2003 UNESCO Memory of the World inscription — `src-unesco-mow-2003`

## Tier-3 carries (flagged)

- 1963 Washington Charlotte meeting and "I am a Luxembourgish boy" line — `src-chronicle-lu-2025-cercle-cite-steichen`
- 1966 "ideal place" remark, second-hand — same source. CNA's "expresses his wish" is preferred where the two diverge.

## Documented gaps (not papered over)

- 1964–1974 storage decade
- Exact 1994 inauguration date and curator of record
- Scope/date of the "first" restoration phase implied by the German page's "second restoration phase" wording
- Detailed 2010–2013 conservation methodology
- Touring-set vs MoMA-originals relationship

## Validator audit

`tvl-tech-bias-validator` (sonnet) returned **REVISE** with two Groundedness FLAGs, both fixed before commit:

1. The site page over-cited the German CNA page for the 1974–1989 partial display when the German source's Key excerpts don't actually record that line. Citation tightened to English page only; footnote [^2] description corrected.
2. The "Steichen Collections" institutional framing wasn't verbatim in either cited source's Key excerpts. Sentence rephrased to drop the unattested label.

Other checks (Sycophancy, Confirmation, Anchoring, Scope creep): PASS.

## Test plan

- [ ] Schema judge: footnote refs balance with definitions; frontmatter valid; source entry tier-1/verified-true convention.
- [ ] Credibility judge: every footnote names a source in `sources/`; tier compliance.
- [ ] Grounding judge: spot-check footnoted quotes against `Key excerpts` blocks of cited source entries.
- [ ] Bias judge: institutional/curatorial perspective is named explicitly in the perspective note; no unmarked promotional voice; gaps openly documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)