### PR TITLE
Expand /tour/ from stub to substantive overview

### DIFF
--- a/research/world-tour.md
+++ b/research/world-tour.md
@@ -110,7 +110,7 @@ The tour cannot be discussed in a politically neutral register. It was the flags
 
 The standard scholarly counter-readings:
 
-- **Roland Barthes, *Mythologies* (1957).** "The Great Family of Man" argues the exhibition's universalising humanism naturalises historical and political difference. Written in response to the Paris stop. In repo as `src-barthes-1957-mythologies` (not re-fetched).
+- **Roland Barthes, *Mythologies* (1957).** "The Great Family of Man" argues the exhibition's universalising humanism naturalises historical and political difference. Written in response to the Paris stop. In repo as `src-barthes-1957` (not re-fetched).
 - **Eric Sandeen, *Picturing an Exhibition* (1995).** The first book-length scholarly study; reads the show within Cold War cultural diplomacy. ToC fetched 2026-04-29 confirms chapters "The family of man on the move" and "The family of man in Moscow." Body text not accessed; **page-level citations should not be added on the basis of this note.**
 - **Fred Turner, *The Democratic Surround* (2013).** Widely cited as the strongest recent reading of the exhibition's liberal-internationalist visual culture. **Not in this repo, not fetched.**
 - **Allan Sekula's essays** ("The Traffic in Photographs," 1981; "Reading an Archive," 1986). Frequently cited as the strongest Marxist critique. **Not in this repo, not fetched.**

--- a/research/world-tour.md
+++ b/research/world-tour.md
@@ -1,0 +1,136 @@
+---
+title: "The world tour, 1955–c.1962/1964/1965: USIA circulation and what is verifiable"
+status: draft
+last_updated: 2026-04-29
+perspective: [institutional, curatorial, contested-figures]
+contested: true
+sources:
+  - src-moma-1955-press-release-book
+  - src-moma-exh-0569-master-checklist
+  - src-moma-archives-highlights-1955
+  - src-moma-exh-2429
+  - src-cna-collections-deu-family-of-man
+  - src-cna-collections-eng-family-of-man
+  - src-cna-education
+  - src-cna-edu-steichen-bio
+  - src-unesco-mow-2003
+  - src-sandeen-1995
+fresh_fetches_this_round:
+  - "https://steichencollections-cna.lu/eng/collections/1_the-family-of-man (2026-04-29) — re-fetched; carries '10 million people throughout the world' attendance figure and 1955–1962 framing for the touring period"
+  - "https://www.thefamilyofman.education/en/historical-context/the-family-of-man-the-book-of-humanity (2026-04-29) — carries USIA commissioning sentence, '10 copies with minor changes sent to nearly 160 towns', '1.5 tonnes / 23 crates / 6 days', 'nearly 10 million visitors', 1955–1964 touring framing, and four geo-located image captions (Guatemala City, Tokyo, Johannesburg, Moscow)"
+  - "https://www.moma.org/calendar/exhibitions/2429 (2026-04-29) — returned HTTP 403; no new tour-specific content captured this round"
+  - "https://archive.org/details/picturingexhibit0000sand (2026-04-29) — Internet Archive borrow-only; ToC visible (chapter titles 'The family of man on the move' and 'The family of man in Moscow' confirmed) but no body text accessible without controlled-digital-lending session, which was not completed"
+  - "https://www.thefamilyofman.education/en/the-family-of-man-an-exhibition-with-international-aura (2026-04-29) — returned HTTP 404; URL from issue brief is no longer live"
+  - "https://www.archives.gov/research/foreign-policy/related-records/rg-306 (2026-04-29) — denied by tool permission system; NARA RG 306 NOT consulted in this round"
+  - "https://catalog.archives.gov/id/10495350 (2026-04-29) — denied by tool permission system; NARA catalog NOT consulted in this round"
+---
+
+# The world tour, 1955–c.1962/1964/1965: USIA circulation and what is verifiable
+
+## Scope and provenance note
+
+This note traces *The Family of Man* after its 8 May 1955 close at MoMA New York: the 1955–56 U.S. domestic tour through six cities, the longer international circulation under United States Information Agency (USIA) auspices into the early-to-mid 1960s, and a brief note on the 1992–94 pre-inscription touring of restored prints. The Luxembourg donation, the storage decade, the 1994 Clervaux installation, and the 2010–13 restoration are treated in `/clervaux/` and `research/clervaux.md`.
+
+Two cautions before any number appears. **First**, the headline aggregate that circulates in secondary literature — "approximately 9 million visitors / 91 venues / 37 countries" — is not anchored in any primary archival source fetched this round. It is carried in this repo's existing `site/exhibition.md` and `site/tour.md` pages with `verified: false` flags pointing to U.S. National Archives Record Group 306 (USIA records). Two attempts to reach NARA finding aids in this round were denied by tool permission system; **NARA RG 306 was not opened this round and is not cited in this note as if it had been.** **Second**, the CNA institutional sources re-fetched this round disagree among themselves: the collections page (English) gives "10 million" / 1955–1962; the education portal gives "nearly 10 million" / 1955–1964 / "ten copies sent to nearly 160 towns"; the Steichen biography page gives an end-date of 1965. None match the "9M / 91 / 37" of secondary literature. These discrepancies are documented in §3–§4 rather than smoothed over.
+
+## 1. Tour overview: what circulated, why, and how
+
+*The Family of Man* did not "tour" in the sense of a single physical installation moving from city to city. From the outset, MoMA produced **multiple circulating editions** — physically distinct copies, partially overlapping with the 1955 New York hang but re-fabricated for travel. The MoMA Master Checklist is headed "1955–56 — An exhibition prepared and circulated by The Museum of Modern Art" (`src-moma-exh-0569-master-checklist`), documenting a circulating edition with a 503-plate core and per-copy variations. The number of copies, the per-copy plate-lists, and the per-copy itineraries would sit in MoMA International Program records and USIA exhibition files; neither was consulted this round.
+
+The CNA education portal (re-fetched 2026-04-29) carries the institutional summary: *"Commissioned by the USIA (United States Information Agency), an American governmental unit created during the Cold War to promote a positive image of the United States in front of the Russian propaganda, the exhibition traveled."* And the logistical sketch: *"Between 1955 and 1964, the exhibition became itinerant and toured the world visiting numerous countries as India, Russia, France, Zimbabwe, South Africa, Mexico, Germany, Japan, Australia… in the form of ten copies with minor changes sent to nearly 160 towns. Each of the copies was weighing one tonne and a half, was packed in twenty-three crates and required more than six days to be mounted/installed."* (`src-cna-education`.) Note that "ten copies sent to nearly 160 towns" is a different unit of measurement from the secondary-literature "91 venues" — copies-cumulative-across-stops vs. unique venues — and the two cannot be reconciled without the underlying tour log; the nine countries are an open-ended sample ("as … …"), not an enumeration.
+
+## 2. The 1955–56 U.S. domestic tour
+
+The U.S. domestic tour is the best-attested portion of the circulation history. The 21 June 1955 MoMA press release (`src-moma-1955-press-release-book`) lists the schedule on its second page:
+
+| City | Venue | Dates |
+|---|---|---|
+| Minneapolis | Minneapolis Institute of Art | Jun 21 – Sept 4, 1955 |
+| Dallas | Dallas Museum of Fine Arts | Oct 7 – Nov 18, 1955 |
+| Cleveland | Cleveland Museum of Art | Jan 24 – March 5, 1956 |
+| Philadelphia | Philadelphia Museum of Art | March 25 – April 29, 1956 |
+| Baltimore | Baltimore Museum of Art | May 30 – July 15, 1956 (approx.) |
+| Pittsburgh | Carnegie Institute | Oct 18 – Nov 29, 1956 |
+
+(All six entries: `src-moma-1955-press-release-book`, p. 2.) The same press release records that an **international edition went separately to the Corcoran Gallery in Washington D.C., June 30 – July 31, 1955** — the earliest documented stop of what would become the USIA international tour, preceding the Minneapolis opening by nine days.
+
+The press release does not give per-city attendance, does not address co-fabrication or parallel touring, and does not extend past 29 November 1956. Receiving-museum archives and MoMA's International Program records would close these gaps; none was consulted this round.
+
+## 3. The USIA international tour (1955–c.1962/1964/1965)
+
+This is where the source material thins, the figures multiply, and the discipline of "claim only what was fetched" becomes load-bearing.
+
+**Attested by sources fetched this round.** The international circulation was commissioned by the USIA: *"Commissioned by the USIA (United States Information Agency)…"* (`src-cna-education`, 2026-04-29). A separate international edition existed from June 1955 onward, opening at the Corcoran Gallery (Washington D.C., 30 June – 31 July 1955) per `src-moma-1955-press-release-book`. The touring period extended into the early-to-mid 1960s, with three different institutional end-dates (see §4). At least nine countries were visited — "India, Russia, France, Zimbabwe, South Africa, Mexico, Germany, Japan, Australia" — presented as an open-ended sample, not an enumeration. The operational format was multi-copy circulation: *"ten copies with minor changes sent to nearly 160 towns. Each of the copies was weighing one tonne and a half, was packed in twenty-three crates and required more than six days to be mounted/installed"* (`src-cna-education`). Total attendance is given by both CNA pages as approximately ten million: *"seen by 10 million people throughout the world"* (`src-cna-collections-eng-family-of-man`); *"nearly 10 million visitors came in search of not only a one moment capture but to witness the whole humanity"* (`src-cna-education`).
+
+**Not attested by anything fetched this round.** The "91 venues" and "37 countries" figures circulate in secondary literature; both are carried in the in-repo wiki pages with `verified: false` flags pointing to NARA RG 306 as the would-be anchor. Nothing fetched corroborates either. The CNA "nearly 160 towns" cannot be unit-converted into "91 venues" without the per-copy tour log — towns may double-count, may or may not include U.S. domestic stops, may use a looser definition of "town" than "venue." The "9 million" attendance figure used by the in-repo wiki pages is also unanchored; both CNA pages fetched this round give *10* million instead. Whether the discrepancy is counting period, inclusion rules, or drift is not adjudicable from what was fetched. A complete tour log was not retrieved: Sandeen 1995 contains a chapter titled "The family of man on the move" — the title is visible on the Internet Archive bibliographic record (2026-04-29) — but the body text is borrow-only and was not accessed.
+
+**A defensible public-facing wording** that does not promote the unverified figures: *Between 1955 and the early-to-mid 1960s, multiple physically distinct copies of* The Family of Man *circulated internationally under the auspices of the United States Information Agency. Institutional summaries — including the CNA's collections pages — give the cumulative international audience as approximately ten million across multiple continents. Other secondary summaries cite ninety-one venues across thirty-seven countries; that more granular figure has not been verified against the underlying USIA records held at the U.S. National Archives in Record Group 306, which were not consulted for this note.*
+
+## 4. The 1962 vs 1964 vs 1965 end-date discrepancy
+
+Three institutional pages from the same CNA source family give three different end-dates, all freshly fetched within the past two weeks:
+
+| Source | Stated end | Verbatim |
+|---|---|---|
+| `src-cna-collections-eng-family-of-man` | **1962** | "travelling exhibition, seen by 10 million people throughout the world" between 1955-1962 |
+| `src-cna-education` | **1964** | "Between 1955 and 1964, the exhibition became itinerant and toured the world…" |
+| `src-cna-edu-steichen-bio` | **1965** | "It opened at MoMA in 1955, then toured the world until 1965 as a consecration of his most ambitious project." |
+
+No single end-date can be defended from the institutional sources alone — the three pages are all CNA-published, all Tier-1 by this repo's rubric, and they disagree by three years. The disagreement is not implausible given how the tour actually worked: a multi-copy circulation can have a "last public showing" date (1962?), a "last institutional venue / prints recovered" date (1964 — aligning with the Luxembourg donation arrival per `src-cna-collections-deu-family-of-man`), and a Steichen-career-end date (1965, on the bio page). The three dates may also simply reflect different copies retiring at different times — at least ten physical copies were in circulation per `src-cna-education`, and they did not retire together. The honest position for the wiki: the tour ran from 1955 into the early-to-mid 1960s; name the three different end-dates and attribute each; do not pick a winner without primary archival evidence.
+
+## 5. Specific named venues — what is and isn't attested
+
+The discipline: **only assert a venue if it is named in a source fetched this round.** International-tour venues so attested:
+
+| Venue | City | Dates | Attestation |
+|---|---|---|---|
+| Corcoran Gallery | Washington D.C., USA | 30 June – 31 July 1955 | `src-moma-1955-press-release-book`, p. 2 |
+| Palacio Protocolo | Guatemala City, Guatemala | 24 August – 18 September 1955 | image caption, fresh fetch `src-cna-education` (2026-04-29) |
+| Takashimaya Department Store | Tokyo, Japan | March – April 1956 | image caption, fresh fetch `src-cna-education` (2026-04-29) |
+| Government Pavilion | Johannesburg, Union of South Africa | 30 August – 13 September 1958 | image caption, fresh fetch `src-cna-education` (2026-04-29) |
+| (Moscow venue, name unspecified) | Moscow, USSR | 1959 (year only) | image-caption mention, fresh fetch `src-cna-education` (2026-04-29) |
+
+Verbatim CNA caption phrasing follows MoMA-authored format, e.g. *"Installation view of the exhibition 'The Family of Man' (travelling exhibition organized by MoMA, NY) in Guatemala, Guatemala City, Palacio Protocolo, August 24 through September 18, 1955."* The U.S. domestic stops (Minneapolis, Dallas, Cleveland, Philadelphia, Baltimore, Pittsburgh) are also fully attested with venues and dates in `src-moma-1955-press-release-book`; see §2.
+
+### Moscow 1959, West Berlin, and the country-level-only list
+
+The Moscow 1959 stop is the most-cited single venue in the reception literature, generally said to have been part of the **American National Exhibition at Sokolniki Park, Moscow, July–September 1959** — the exhibition of the Nixon–Khrushchev "Kitchen Debate." That identification is plausible and widely repeated, **but it is not anchored in any source fetched this round.** The CNA education portal mentions Moscow only by year, with no venue, no dates, no diplomatic context. The Sandeen 1995 chapter "The family of man in Moscow" would presumably address it; the body text was not accessible. The honest position: Moscow 1959 is attested at year-level only.
+
+**West Berlin** is flagged in the issue brief as a "notable host-city"; it is not named in any source fetched this round. No Berlin-stop claim should be added on the basis of this note.
+
+The CNA's nine-country list resolves to specific venues for only three (Tokyo 1956; Johannesburg 1958; Moscow 1959 year-level). The remaining six are attested at country-level only — **no city, venue, or date can be cited for India, France, Zimbabwe, Mexico, Germany, or Australia from this round's fetches.** "Zimbabwe" is itself anachronistic — the country was Southern Rhodesia during the tour period — likely a later editorial regularisation.
+
+## 6. The 1992 / 1993–94 pre-inscription tour wave
+
+A distinct and much later touring wave, separate from the 1955–c.1965 USIA circulation, is briefly recorded on the UNESCO Memory of the World register entry (`src-unesco-mow-2003`, re-fetched 2026-04-29): *"during 1992 and 1993–1994, restored versions traveled internationally, including stops in Toulouse, Tokyo, and Hiroshima."* This wave post-dates the original USIA tour by approximately three decades, used **restored** prints (conservation-treated, not freshly-fabricated), preceded the 1994 permanent installation at Clervaux Castle, and may have contributed visibility to the 2002 Memory of the World nomination. The venue list is explicitly partial ("including stops in"); the full itinerary would be in CNA records and was not fetched. **This is a separate, second touring wave**, organised under different institutional auspices (CNA / Luxembourg state, not USIA / U.S. State Department), in a post-Cold-War context — sometimes confused in popular accounts with the original USIA tour.
+
+## 7. Cold War cultural diplomacy: framing and counter-framing
+
+The tour cannot be discussed in a politically neutral register. It was the flagship exhibition of a U.S. government agency whose statutory purpose was the international promotion of American interests during the Cold War. The CNA education page states this baldly: the USIA was *"an American governmental unit created during the Cold War to promote a positive image of the United States in front of the Russian propaganda"* (`src-cna-education`). The grammar — "in front of the Russian propaganda" — itself encodes a framing.
+
+The standard scholarly counter-readings:
+
+- **Roland Barthes, *Mythologies* (1957).** "The Great Family of Man" argues the exhibition's universalising humanism naturalises historical and political difference. Written in response to the Paris stop. In repo as `src-barthes-1957-mythologies` (not re-fetched).
+- **Eric Sandeen, *Picturing an Exhibition* (1995).** The first book-length scholarly study; reads the show within Cold War cultural diplomacy. ToC fetched 2026-04-29 confirms chapters "The family of man on the move" and "The family of man in Moscow." Body text not accessed; **page-level citations should not be added on the basis of this note.**
+- **Fred Turner, *The Democratic Surround* (2013).** Widely cited as the strongest recent reading of the exhibition's liberal-internationalist visual culture. **Not in this repo, not fetched.**
+- **Allan Sekula's essays** ("The Traffic in Photographs," 1981; "Reading an Archive," 1986). Frequently cited as the strongest Marxist critique. **Not in this repo, not fetched.**
+
+The repo's `/reception/` page and `research/sections.md` already engage Barthes at the level of the exhibition's content. The contribution of the present note is the layer specific to the *tour*: the same humanist argument, shipped abroad under USIA auspices, functioned as an instrument of state cultural policy.
+
+## 8. After the tour: what happened to the prints
+
+Per the CNA's German collections page: *"Die amerikanische Regierung schenkt Luxemburg auf Wunsch Edward Steichens die letzte vollständige Version der Wanderausstellung"* — *the American government donates to Luxembourg, at Edward Steichen's request, the last complete version of the touring exhibition* (`src-cna-collections-deu-family-of-man`). The donation arrived in Luxembourg in **1964–1966** per the CNA chronology. The full Luxembourg chapter — storage, partial display 1974–1989, the 1994 permanent installation at Clervaux Castle, the 2010–2013 restoration — is treated in `research/clervaux.md` and `/clervaux/` and is not duplicated here. What the donation framing tells us about the tour: at least one of the "ten copies with minor changes" survived in complete form and was donated whole to Luxembourg, consistent with the multi-copy operational model. The fates of the other copies are not addressed in any source fetched this round.
+
+## 9. Known gaps and open tasks
+
+- **NARA RG 306 (USIA records)** — the single most consequential gap. Two fetches attempted this round, both denied by tool permission system. A future pass should consult the RG 306 finding aid (Exhibits Division), extract per-copy / per-venue tour logs to resolve "91 / 37 / 9M", and recover the closing-administration date to resolve the 1962/1964/1965 discrepancy.
+- **MoMA International Program records.** Not fetched.
+- **Sandeen 1995, full text** — particularly the "on the move" and "in Moscow" chapters. CDL borrow not completed.
+- **Turner 2013** and **Sekula's essays** — not in repo, not fetched. Future entries under `sources/2010s/` and `sources/1980s/`.
+- **Receiving-museum archives** for the six U.S. domestic stops; **Eisenhower Presidential Library** holdings on the 1959 American National Exhibition; **specific 1992–94 itinerary** beyond Toulouse / Tokyo / Hiroshima; **West Berlin reception** — none consulted or corroborated this round.
+
+## 10. Citation provenance summary
+
+Verifiable claims rest on `src-moma-1955-press-release-book` (six-city U.S. tour schedule and Corcoran international-edition stop); `src-moma-exh-0569-master-checklist` (the documented checklist is the circulating edition); `src-cna-collections-eng-family-of-man` (re-fetched 2026-04-29) and `src-cna-collections-deu-family-of-man` (donation framing, 1962-end, 10-million); `src-cna-education` (re-fetched 2026-04-29) for the verbatim USIA-commissioning sentence, the ten-copies / 160-towns / 1.5-tonnes / 23-crates / 6-days block, the "nearly 10 million" figure, the 1955–1964 framing, and the four geo-located captions (Guatemala City, Tokyo, Johannesburg, Moscow); `src-cna-edu-steichen-bio` (1965-end framing); `src-unesco-mow-2003` (re-fetched 2026-04-29; 1992 / 1993–94 pre-inscription touring); `src-sandeen-1995` (chapter-title attestation only — body text not accessed).
+
+The headline aggregate "9 million / 91 / 37" is **not** anchored in any source fetched this round. Its conventional anchor — NARA RG 306 — was not consulted; two attempts were denied by tool permission system. Do not promote the figure to verified status on the basis of this note, and do not cite NARA RG 306 in any wiki page that depends on this note for support. Turner 2013 and Sekula's essays are named here as standard critical references; neither is in this repo and neither was fetched. Specific claims attributed to either must rest on a future direct read.

--- a/site/tour.md
+++ b/site/tour.md
@@ -107,7 +107,7 @@ The tour cannot be discussed in a politically neutral register. It was the flags
 
 The standard scholarly counter-readings:
 
-- **Roland Barthes, *Mythologies* (1957).** *"The Great Family of Man"* argues that the exhibition's universalising humanism naturalises historical and political difference. Written in response to the Paris stop. In this wiki as `src-barthes-1957-mythologies`; engaged in detail on the [Reception page]({{ '/reception/' | relative_url }}).
+- **Roland Barthes, *Mythologies* (1957).** *"The Great Family of Man"* argues that the exhibition's universalising humanism naturalises historical and political difference. Written in response to the Paris stop. In this wiki as `src-barthes-1957`; engaged in detail on the [Reception page]({{ '/reception/' | relative_url }}).
 - **Eric Sandeen, *Picturing an Exhibition: The Family of Man and 1950s America* (1995).** The first book-length scholarly study; situates the show within Cold War cultural diplomacy. In this wiki as `src-sandeen-1995`. The Internet Archive listing confirms chapters titled *"The family of man on the move"* and *"The family of man in Moscow"*; the body text is borrow-only and was not accessed for this page.[^4]
 - **Fred Turner, *The Democratic Surround* (2013).** Widely cited as the strongest recent reading of the exhibition's liberal-internationalist visual culture. **Not in this wiki**, not consulted; named here only as a pointer for future research.
 - **Allan Sekula's essays** ("The Traffic in Photographs," 1981; "Reading an Archive," 1986). Frequently cited as the strongest Marxist critique of the show as ideological work. **Not in this wiki**, not consulted; named here only as a pointer.

--- a/site/tour.md
+++ b/site/tour.md
@@ -6,25 +6,139 @@ permalink: /tour/
 edit_dir: site
 ---
 
-_This article is pending research. A Phase 2 investigation will populate it._
-
 {% include image.html
    src="/assets/images/family-of-man-schoolchildren.jpg"
    alt="Schoolchildren viewing The Family of Man during the USIA tour"
-   caption="Schoolchildren viewing a Family of Man tour-edition installation. Photographic record from the USIA's documentation of the show's 1955–1962 international tour."
+   caption="Schoolchildren viewing a Family of Man tour-edition installation. Photographic record from the USIA's documentation of the international tour."
    credit="U.S. National Archives · DPLA · Public domain"
    credit_url="https://commons.wikimedia.org/wiki/File:%22Family_of_Man%22_Exhibit,_Schoolchildren_-_DPLA_-_bc02eb41421152da8c2e735ea8fd7a9a.jpg" %}
 
-Between 1955 and 1962, editions of the exhibition traveled under the auspices of the **United States Information Agency (USIA)**. The figures commonly cited — ninety-one venues across thirty-seven countries, roughly nine million visitors — are to be verified against USIA records in the U.S. National Archives (RG 306) before any specific number appears here without a source.
+<nav class="page-toc" aria-label="Page contents">
+  <div class="kicker">On this page</div>
+  <ol>
+    <li><a href="#how-the-tour-actually-worked">How the tour actually worked</a></li>
+    <li><a href="#the-1955-56-u-s-domestic-tour">The 1955–56 U.S. domestic tour</a></li>
+    <li><a href="#the-international-edition-from-june-1955">The international edition, from June 1955</a></li>
+    <li><a href="#verifiable-venues-abroad">Verifiable venues abroad</a></li>
+    <li><a href="#the-headline-aggregate-problem">The headline aggregate problem</a></li>
+    <li><a href="#three-end-dates">Three end-dates: 1962, 1964, 1965</a></li>
+    <li><a href="#the-1992-94-pre-inscription-touring">The 1992–94 pre-inscription touring</a></li>
+    <li><a href="#cold-war-cultural-diplomacy">Cold War cultural diplomacy</a></li>
+    <li><a href="#after-the-tour">After the tour</a></li>
+  </ol>
+</nav>
+
+After the New York show closed on 8 May 1955, *The Family of Man* did not stop — it multiplied. Over the next decade, multiple physically distinct copies circulated under the auspices of the **United States Information Agency (USIA)**, reaching audiences across continents and becoming one of the most-cited instruments of mid-century U.S. cultural diplomacy. This page traces what is *verifiable* about that circulation from sources in this wiki, and is unusually explicit about what is *not*.
+
+## How the tour actually worked
+
+The tour was not a single physical installation moving from city to city. From the outset, MoMA produced **multiple circulating editions** — physically distinct copies, partially overlapping with the 1955 New York hang but re-fabricated for travel.[^1] The CNA Luxembourg education portal characterises the operational model: between 1955 and 1964, *"the exhibition became itinerant and toured the world ... in the form of ten copies with minor changes sent to nearly 160 towns. Each of the copies was weighing one tonne and a half, was packed in twenty-three crates and required more than six days to be mounted/installed."*[^2]
+
+The same page records the commissioning attribution: *"Commissioned by the USIA (United States Information Agency), an American governmental unit created during the Cold War to promote a positive image of the United States in front of the Russian propaganda, the exhibition traveled."*[^2] The grammar — *"in front of the Russian propaganda"* — itself encodes a Cold War framing; the CNA inherits the institutional voice of its donor.
+
+This multi-copy structure matters for everything that follows. A "venue count" can either count unique places visited or copy-stops cumulative across all ten copies; an "attendance figure" depends on whether co-located copies are aggregated; an "end-date" can be the last public showing, the last institutional venue, or the date the prints were physically recovered. The same operational reality produces different numbers depending on what you decide to count.
+
+## The 1955–56 U.S. domestic tour
+
+The U.S. domestic portion is the best-attested. The 21 June 1955 MoMA press release lists the schedule for six cities:[^3]
+
+| City | Venue | Dates |
+|---|---|---|
+| Minneapolis | Minneapolis Institute of Art | 21 Jun – 4 Sept 1955 |
+| Dallas | Dallas Museum of Fine Arts | 7 Oct – 18 Nov 1955 |
+| Cleveland | Cleveland Museum of Art | 24 Jan – 5 Mar 1956 |
+| Philadelphia | Philadelphia Museum of Art | 25 Mar – 29 Apr 1956 |
+| Baltimore | Baltimore Museum of Art | 30 May – 15 Jul 1956 |
+| Pittsburgh | Carnegie Institute | 18 Oct – 29 Nov 1956 |
+
+The MoMA press release does not give per-city attendance, does not address co-fabrication or parallel touring, and does not extend past 29 November 1956.[^3] Receiving-museum archives and MoMA's International Program records would close these gaps; none was consulted for this page.
+
+## The international edition, from June 1955
+
+A separate **international edition** went on the road as early as **30 June 1955** — nine days *before* the Minneapolis opening of the U.S. domestic tour. The press release records its first stop at the **Corcoran Gallery in Washington D.C., 30 June – 31 July 1955**.[^3] From there, the international circulation moved abroad under USIA auspices, although the press release itself does not extend past November 1956 and a complete itinerary is not in any source consulted for this wiki.
+
+## Verifiable venues abroad
+
+The discipline applied to this page: **only assert a venue if it is named in a source that has been fetched into this wiki.** The international stops so attested:[^2][^3]
+
+| Venue | City | Country | Dates |
+|---|---|---|---|
+| Corcoran Gallery | Washington D.C. | USA | 30 Jun – 31 Jul 1955 |
+| Palacio Protocolo | Guatemala City | Guatemala | 24 Aug – 18 Sept 1955 |
+| Takashimaya Department Store | Tokyo | Japan | March – April 1956 |
+| Government Pavilion | Johannesburg | Union of South Africa | 30 Aug – 13 Sept 1958 |
+| (venue unspecified) | Moscow | USSR | 1959 (year only) |
+
+The CNA portal also gives a country-level list — *"India, Russia, France, Zimbabwe, South Africa, Mexico, Germany, Japan, Australia"* — but it is presented as an open-ended sample, not an enumeration.[^2] Three of those countries resolve to specific venues in the table above; for the other six, **no city, venue, or date is attested** in sources consulted for this wiki and none is asserted here. The label *"Zimbabwe"* is anachronistic for the 1955–1964 tour period — the country was Southern Rhodesia until 1980 — and is most likely a later editorial regularisation by the CNA portal.
+
+The **Moscow 1959 stop** is the most-cited single venue in the reception literature, generally said to have been part of the **American National Exhibition at Sokolniki Park, Moscow, July–September 1959** — the show of the Nixon–Khrushchev "Kitchen Debate." That identification is plausible and widely repeated, **but it is not anchored in any source consulted for this wiki**: the CNA portal mentions Moscow only by year, with no venue, no dates, no diplomatic context.[^2] Sandeen 1995 contains a chapter titled *"The family of man in Moscow"* — the title is visible on the Internet Archive bibliographic record — but the body text is borrow-only and was not accessed for this page.[^4] The Eisenhower Presidential Library's holdings on the 1959 American National Exhibition would be the natural primary source; not consulted.
+
+## The headline aggregate problem
+
+The figures most commonly cited for the international tour — *"9 million visitors / 91 venues / 37 countries"* — circulate widely in secondary literature. They are carried in this wiki's other pages with `verified: false` flags pointing to **U.S. National Archives Record Group 306 (USIA records)** as the would-be primary anchor. NARA RG 306 has not been consulted for this page (two fetch attempts during this round were denied), and **the figures should not be promoted to confirmed status on the basis of anything in this wiki to date**.
+
+The CNA institutional pages give *different* numbers in *different units*. The collections page (English) describes the show as a *"travelling exhibition, seen by 10 million people throughout the world"* between 1955 and 1962.[^5] The education portal gives *"nearly 10 million visitors"* across *"ten copies ... sent to nearly 160 towns"* between 1955 and 1964.[^2] The "ten copies / 160 towns" figure is **not unit-equivalent** to "91 venues" — towns may double-count (multiple copies stopping in the same town count once or many times), may or may not include U.S. domestic stops, and may use a looser definition of *"town"* than *"venue."* The two cannot be reconciled without the per-copy tour log.
+
+A defensible public-facing summary that does not promote any unverified figure: between 1955 and the early-to-mid 1960s, multiple physically distinct copies of *The Family of Man* circulated internationally under USIA auspices, reaching a cumulative audience that institutional sources put at approximately ten million across multiple continents. More granular figures — 91 venues, 37 countries, 9 million — circulate in secondary literature but have not been verified against the underlying USIA records for this wiki.
+
+## Three end-dates: 1962, 1964, 1965
+
+Three CNA-published institutional pages — same custodial institution, same Tier-1 status — give three different end-dates for the tour:
+
+| Source | End-date | Verbatim wording |
+|---|---|---|
+| `src-cna-collections-eng-family-of-man` | **1962** | *"travelling exhibition, seen by 10 million people throughout the world"* between 1955–1962 |
+| `src-cna-education` | **1964** | *"Between 1955 and 1964, the exhibition became itinerant and toured the world..."* |
+| `src-cna-edu-steichen-bio` | **1965** | *"It opened at MoMA in 1955, then toured the world until 1965 as a consecration of his most ambitious project."* |
+
+[^5][^2][^8]
+
+The disagreement is not implausible given how the tour worked. A multi-copy circulation can have a *last public showing* date (1962?), a *last institutional venue / prints recovered* date (1964 — aligning with the Luxembourg donation arrival), and a *Steichen-career-end* date (1965, on the bio page). The three dates may also simply reflect different copies retiring at different times: at least ten physical copies were in circulation, and they did not retire together. The honest position for this wiki: the tour ran from 1955 into the early-to-mid 1960s; the three different end-dates are named and attributed; no winner is picked without primary archival evidence.
+
+## The 1992–94 pre-inscription touring
+
+A distinct and much later touring wave — separate from the 1955–c.1965 USIA circulation — is briefly recorded on the UNESCO Memory of the World register entry: during *"1992 and 1993–1994, restored versions traveled internationally, including stops in Toulouse, Tokyo, and Hiroshima."*[^7] This wave post-dates the original USIA tour by roughly three decades, used **restored** prints (conservation-treated, not freshly-fabricated), preceded the 1994 permanent installation at Clervaux Castle, and may have contributed visibility to the 2002 Memory of the World nomination. The venue list is explicitly partial (*"including stops in"*); the full itinerary would be in CNA records and is not in this wiki.
+
+This is **a separate, second touring wave**, organised under different institutional auspices (CNA / Luxembourg state, not USIA / U.S. State Department), in a post-Cold-War context. It is sometimes confused in popular accounts with the original USIA tour and should be kept distinct.
+
+## Cold War cultural diplomacy
+
+The tour cannot be discussed in a politically neutral register. It was the flagship exhibition of a U.S. government agency whose statutory purpose was the international promotion of American interests during the Cold War; the CNA portal states this baldly.[^2] The image of mid-century humanism the show carried abroad — Steichen's universal "essential oneness of mankind" — was, materially, an instrument of U.S. soft power.
+
+The standard scholarly counter-readings:
+
+- **Roland Barthes, *Mythologies* (1957).** *"The Great Family of Man"* argues that the exhibition's universalising humanism naturalises historical and political difference. Written in response to the Paris stop. In this wiki as `src-barthes-1957-mythologies`; engaged in detail on the [Reception page]({{ '/reception/' | relative_url }}).
+- **Eric Sandeen, *Picturing an Exhibition: The Family of Man and 1950s America* (1995).** The first book-length scholarly study; situates the show within Cold War cultural diplomacy. In this wiki as `src-sandeen-1995`. The Internet Archive listing confirms chapters titled *"The family of man on the move"* and *"The family of man in Moscow"*; the body text is borrow-only and was not accessed for this page.[^4]
+- **Fred Turner, *The Democratic Surround* (2013).** Widely cited as the strongest recent reading of the exhibition's liberal-internationalist visual culture. **Not in this wiki**, not consulted; named here only as a pointer for future research.
+- **Allan Sekula's essays** ("The Traffic in Photographs," 1981; "Reading an Archive," 1986). Frequently cited as the strongest Marxist critique of the show as ideological work. **Not in this wiki**, not consulted; named here only as a pointer.
+
+The contribution this page makes — over and above the [Reception page]({{ '/reception/' | relative_url }}), which engages Barthes at the level of the exhibition's content — is the layer specific to the *tour*: the same humanist argument, shipped abroad in ten parallel copies under USIA auspices, functioned as an instrument of state cultural policy.
+
+## After the tour
+
+Per the CNA's German collections page: *"Die amerikanische Regierung schenkt Luxemburg auf Wunsch Edward Steichens die letzte vollständige Version der Wanderausstellung"* — *the American government donates to Luxembourg, at Edward Steichen's request, the last complete version of the touring exhibition.*[^6] The donation arrived in Luxembourg during **1964–1966**.
+
+That phrasing — *"the last complete version"* — is informative for the tour. At least one of the ten copies survived in complete form and was donated whole to Luxembourg, consistent with the multi-copy operational model. **The fates of the other copies are not addressed in any source consulted for this wiki.** A future research pass should attempt to recover, from MoMA International Program records or USIA exhibition files, the disposition of each copy at tour-end.
+
+The full Luxembourg chapter — storage, partial display 1974–1989, the 1994 permanent installation at Clervaux Castle, the 2010–2013 restoration — is on the [Clervaux page]({{ '/clervaux/' | relative_url }}) and is not duplicated here.
 
 {% include image.html
    src="/assets/images/clervaux-signage.jpg"
    alt="Exterior signage of the Family of Man exhibition at Clervaux"
-   caption="Clervaux signage for the permanent installation — the final resting place of the prints after the 1955–62 tour."
+   caption="Clervaux signage for the permanent installation — the final resting place of the prints after the tour."
    credit="Joachim Köhler · CC BY-SA 3.0"
    credit_url="https://commons.wikimedia.org/wiki/File:Clerf-FamilyOfMan-20060908.JPG" %}
 
 <div class="perspective-note">
   <strong>Perspective note</strong>
-  The tour was a flagship of Cold War cultural diplomacy. Fred Turner (<em>The Democratic Surround</em>, 2013) reads it as an instrument of liberal internationalism; Eric Sandeen (1995) reads its reception venue-by-venue; Allan Sekula reads it as ideological work. Articles under this topic must name their sources.
+  This page is told mostly through the institutional voice of CNA Luxembourg (which inherits Steichen's framing) and MoMA's 1955 press record. Neither source is critically distant from the show's universalist argument; for that, see the <a href="{{ '/reception/' | relative_url }}">Reception page</a> on Barthes (1957) and the wider critical thread. The headline aggregate (~9 million visitors / 91 venues / 37 countries) widely cited in secondary literature is unverified pending consultation of USIA records at the U.S. National Archives (Record Group 306); the CNA's "10 million visitors / ten copies / ~160 towns" framing is given here as an institutional alternative, not as a reconciliation. The 1962 / 1964 / 1965 end-date discrepancy among CNA pages is documented openly. Turner 2013 and Sekula's essays are named as standard critical references but are not in this wiki and were not consulted; specific claims attributed to either must rest on a future direct read. Full provenance, fresh-fetch log, and an open-tasks list — including NARA RG 306, MoMA International Program records, the 1959 Eisenhower Library holdings, and the 1992–94 itinerary detail — are in <a href="https://github.com/danlex/thefamilyofman/blob/main/research/world-tour.md"><code>research/world-tour.md</code></a>.
 </div>
+
+[^1]: Museum of Modern Art, *Master Checklist for Exhibition #569 (The Family of Man)*. `src-moma-exh-0569-master-checklist`. The checklist is headed *"1955–56 — An exhibition prepared and circulated by The Museum of Modern Art"* and documents the circulating-edition model.
+[^2]: Centre national de l'audiovisuel (CNA), Luxembourg. "The Family of Man, the book of humanity" (educational portal). `src-cna-education`. Re-verified 2026-04-29. Anchors the USIA-commissioning attribution; the 1955–1964 touring frame; the *"ten copies with minor changes sent to nearly 160 towns"* operational model with per-copy logistics (1.5 tonnes / 23 crates / 6 days); the *"nearly 10 million visitors"* attendance figure; the open-ended country list; and four geo-located image captions for tour stops in Guatemala City (1955), Tokyo (1956), Johannesburg (1958), and Moscow (1959, year-only).
+[^3]: Museum of Modern Art press release for *The Family of Man* book publication, 21 June 1955. `src-moma-1955-press-release-book`. Page 2 carries the U.S. domestic six-city tour schedule (Minneapolis → Dallas → Cleveland → Philadelphia → Baltimore → Pittsburgh, June 1955 – November 1956) and records the international edition's first stop at the Corcoran Gallery, Washington D.C., 30 June – 31 July 1955.
+[^4]: Eric Sandeen, *Picturing an Exhibition: The Family of Man and 1950s America* (Albuquerque: University of New Mexico Press, 1995). `src-sandeen-1995`. Tier 2. Internet Archive bibliographic record (fetched 2026-04-29) confirms chapter titles *"The family of man on the move"* and *"The family of man in Moscow"*; body text is borrow-only and was not accessed for this page. Page-level citations are deferred until a direct read is completed.
+[^5]: Centre national de l'audiovisuel (CNA), Luxembourg. *The Family of Man* (English collections page). `src-cna-collections-eng-family-of-man`. Re-verified 2026-04-29. Anchors the *"travelling exhibition, seen by 10 million people throughout the world"* wording and the **1955–1962** tour-period framing.
+[^6]: Centre national de l'audiovisuel (CNA), Luxembourg. *The Family of Man / Familio de homo* (German collections page). `src-cna-collections-deu-family-of-man`. Anchors the *"letzte vollständige Version der Wanderausstellung"* donation framing.
+[^7]: UNESCO. *Family of Man*, Memory of the World International Register entry. `src-unesco-mow-2003`. Re-verified 2026-04-29. Anchors the 1992 / 1993–1994 pre-inscription touring with venues in Toulouse, Tokyo, and Hiroshima.
+[^8]: Centre national de l'audiovisuel (CNA), Luxembourg. "Edward Steichen: From a Man of His Time to an Artist Out of Time" (educational portal). `src-cna-edu-steichen-bio`. Anchors the **1965** end-date: *"It opened at MoMA in 1955, then toured the world until 1965 as a consecration of his most ambitious project."*

--- a/sources/1990s/sandeen-1995-picturing-an-exhibition.md
+++ b/sources/1990s/sandeen-1995-picturing-an-exhibition.md
@@ -6,10 +6,10 @@ year: 1995
 type: book
 publisher: "University of New Mexico Press, Albuquerque"
 url: "https://archive.org/details/picturingexhibit0000sand"
-accessed: 2026-04-19
+accessed: 2026-04-29
 tier: 2
 language: en
-tags: [scholarship, reception, exhibition-history, sandeen, cold-war]
+tags: [scholarship, reception, exhibition-history, sandeen, cold-war, world-tour]
 ---
 
 ## Citation
@@ -24,6 +24,10 @@ The first book-length scholarly study of *The Family of Man*. Sandeen reconstruc
 
 - Reviewed in *The American Historical Review* 102, no. 1 (Feb. 1997): 218, and in *Journal of American Studies* 30 (1996): 476–477 — both reviews note Sandeen's reconstruction of the exhibition's thematic sequencing from photograph-by-photograph analysis of the MoMA installation and catalog, and his critical framing of the show's humanist argument against its Cold War political context. (Review metadata verified against Oxford Academic and Cambridge Core 2026-04-19; full review text not retrieved here.)
 - Specific page-level citations for particular claims about section structure are deferred until a physical copy or an unrestricted scan is consulted. Internet Archive's borrowable scan (`https://archive.org/details/picturingexhibit0000sand`) was indexed as of 2026-04-19 but required a controlled-digital-lending session we did not complete during this PR; exact page numbers are a documented open task.
+
+Internet Archive ToC re-verification (2026-04-29):
+
+- The book's table of contents — visible without entering a controlled-digital-lending session — confirms two tour-relevant chapter titles: **"The family of man on the move"** and **"The family of man in Moscow."** The body text of both chapters remains borrow-only and was not accessed in this round; chapter-title attestation only.
 
 ## Notes
 

--- a/sources/2010s/cna-collections-eng-family-of-man.md
+++ b/sources/2010s/cna-collections-eng-family-of-man.md
@@ -10,7 +10,7 @@ accessed: 2026-04-29
 tier: 1
 language: en
 verified: true
-tags: [cna, clervaux, donation-1964, restoration-2010-2013, family-of-man]
+tags: [cna, clervaux, donation-1964, restoration-2010-2013, family-of-man, world-tour]
 ---
 
 ## Citation
@@ -30,6 +30,10 @@ The English-language counterpart to the CNA's German collections page (`src-cna-
 - "**July 2013** — Reopening following renovation of exhibition rooms and restoration of photographs."
 - "The restoration campaign has been led in collaboration with the Studio Berselli from Milan, Italy (Silvia Berselli, Roberta Piantavigna, Francesca Vantellini, Isabel Dimas)."
 - "the exhibition rooms featuring a very sober architecture conceived by designer Nathalie Jacoby (NJOY)."
+
+Tour-period framing (re-verified 2026-04-29):
+
+- The page describes *The Family of Man* as a "travelling exhibition, seen by 10 million people throughout the world" between **1955 and 1962**.
 
 ## Notes
 

--- a/sources/2010s/cna-education-family-of-man.md
+++ b/sources/2010s/cna-education-family-of-man.md
@@ -6,21 +6,24 @@ year: 2015
 type: website
 publisher: "Centre national de l'audiovisuel, Luxembourg"
 url: "https://www.thefamilyofman.education/en/historical-context/the-family-of-man-the-book-of-humanity"
-accessed: 2026-04-19
+accessed: 2026-04-29
 tier: 1
 language: en
-tags: [cna, clervaux, education, themes, steichen]
+verified: true
+tags: [cna, clervaux, education, themes, steichen, world-tour, usia]
 ---
 
 ## Citation
 
-Centre national de l'audiovisuel (CNA), Luxembourg. "The Family of Man, the book of humanity." Educational portal accompanying the permanent installation at Clervaux Castle. Accessed 2026-04-19. https://www.thefamilyofman.education/en/historical-context/the-family-of-man-the-book-of-humanity
+Centre national de l'audiovisuel (CNA), Luxembourg. "The Family of Man, the book of humanity." Educational portal accompanying the permanent installation at Clervaux Castle. Accessed 2026-04-29. https://www.thefamilyofman.education/en/historical-context/the-family-of-man-the-book-of-humanity
 
 ## Relevance
 
-The CNA is the institutional custodian of the original prints of *The Family of Man*, permanently installed at Clervaux Castle since 1994. Its educational portal is an institutional Tier-1 source and is one of the places that publishes a count of "37 themes" for the exhibition's thematic organization — conflicting with UNESCO's (2003) figure of 32. Useful both as a list-of-themes signal and as an indicator of the counting discrepancy across institutional sources.
+The CNA is the institutional custodian of the original prints of *The Family of Man*, permanently installed at Clervaux Castle since 1994. Its educational portal is an institutional Tier-1 source and is one of the places that publishes a count of "37 themes" for the exhibition's thematic organization — conflicting with UNESCO's (2003) figure of 32. Re-verification 2026-04-29 surfaced substantial additional content on the international tour: the USIA-commissioning attribution, the multi-copy operational model ("ten copies sent to nearly 160 towns"), per-copy logistics (1.5 tonnes / 23 crates / 6 days to install), an attendance figure of "nearly 10 million," a 1955–1964 touring frame, and four geo-located image captions for tour stops in Guatemala City (1955), Tokyo (1956), Johannesburg (1958), and Moscow (1959).
 
 ## Key excerpts / pages
+
+Themes and curatorial framing:
 
 - Themes explicitly named (not exhaustive): "love, childbirth, work, family, education, childhood, war, peace."
 - "37 themes like a photo-essay about human development and cycles of life."
@@ -29,7 +32,26 @@ The CNA is the institutional custodian of the original prints of *The Family of 
 - Sandburg, quoted as: "There is one man in the world and his name is All man." (The CNA site reproduces a shortened form; the longer attested opening lines are found quoted separately in press and secondary literature.)
 - Steichen quoted: "[The Family of Man] was conceived as a mirror of the universal elements and emotions in the everydayness of life – as a mirror of the essential oneness of mankind throughout the world." (matches the MoMA June 21, 1955 press release)
 
+USIA commissioning and tour structure (captured 2026-04-29):
+
+- USIA attribution: *"Commissioned by the USIA (United States Information Agency), an American governmental unit created during the Cold War to promote a positive image of the United States in front of the Russian propaganda, the exhibition traveled."*
+- Multi-copy circulation logistics: *"Between 1955 and 1964, the exhibition became itinerant and toured the world visiting numerous countries as India, Russia, France, Zimbabwe, South Africa, Mexico, Germany, Japan, Australia… in the form of ten copies with minor changes sent to nearly 160 towns. Each of the copies was weighing one tonne and a half, was packed in twenty-three crates and required more than six days to be mounted/installed."*
+- Attendance: *"nearly 10 million visitors came in search of not only a one moment capture but to witness the whole humanity."*
+- Tour frame: **1955–1964** (this page's framing; conflicts with both `src-cna-collections-eng-family-of-man`'s **1962** end-date and `src-cna-edu-steichen-bio`'s **1965** end-date — see `research/world-tour.md` §4).
+
+Tour-stop image captions (verbatim, captured 2026-04-29):
+
+- *"Installation view of the exhibition 'The Family of Man' (travelling exhibition organized by MoMA, NY) in Guatemala, Guatemala City, Palacio Protocolo, August 24 through September 18, 1955."*
+- Tokyo, Takashimaya Department Store, March – April 1956 (caption follows the same MoMA-authored format).
+- Johannesburg, Government Pavilion, 30 August – 13 September 1958.
+- Moscow, USSR, 1959 (year-only mention — venue and dates not on the caption).
+
 ## Notes
 
+- Originally accessed 2026-04-19; re-verified 2026-04-29 with substantial additional tour-period content captured. The earlier excerpts (themes count, Steichen quotation, Sandburg shortened form) were confirmed verbatim against the re-fetch.
 - The CNA education portal enumerates a partial, illustrative list of themes but does not publish a canonical numbered list of all 37. Until a primary enumeration is confirmed (either from the 1955 catalog's sequencing or from CNA's exhibition-room signage), any repo claim of "37 sections with titles X, Y, Z" would be a fabrication.
+- The "ten copies / 160 towns" figure is in different units from the secondary-literature "91 venues / 37 countries" carried in the in-repo wiki pages with `verified: false`. The two cannot be reconciled without per-copy tour logs (USIA records, NARA RG 306). Do not promote either figure to verified status from this source alone.
+- The "nearly 10 million" attendance figure conflicts with the in-repo wiki pages' "9 million" figure (carried with `verified: false`). The CNA collections English page also gives "10 million." Repo should resolve to "approximately ten million" with both anchors cited, until NARA RG 306 settles the figure.
+- The page's CNA-authored tone in the USIA-commissioning sentence ("in front of the Russian propaganda") encodes a framing — the page is institutional/curatorial and inherits a Cold-War lens. The four image captions, by contrast, are MoMA-authored installation-view metadata and are factual, not editorial.
+- Country list ("India, Russia, France, Zimbabwe, South Africa, Mexico, Germany, Japan, Australia") is presented as an open-ended sample ("as … …"), not an enumeration. "Zimbabwe" is anachronistic for the 1955–1964 tour period (the country was Southern Rhodesia until 1980); likely a later editorial regularisation, flagged here for clarity.
 - Perspective: institutional / curatorial (CNA inherits Steichen's framing).


### PR DESCRIPTION
Closes #46.

## Summary

- Rewrites \`site/tour.md\` (~2,720 words, 9 sections + TOC + 2 tables + footnoted citations + perspective note). Both pre-existing images preserved.
- Adds \`research/world-tour.md\` (~3,000 words) with explicit gaps inventory.
- Updates three source entries with new excerpts captured from 2026-04-29 fresh fetches:
  - \`src-cna-education\`: USIA-commissioning sentence, ten-copies/160-towns operational model, "nearly 10 million" attendance, 1955-1964 framing, four geo-located image captions (Guatemala City 1955, Tokyo 1956, Johannesburg 1958, Moscow 1959).
  - \`src-cna-collections-eng-family-of-man\`: "travelling exhibition, seen by 10 million people throughout the world" 1955-1962 framing.
  - \`src-sandeen-1995\`: Internet Archive ToC re-verification — chapter titles "The family of man on the move" / "The family of man in Moscow" confirmed at ToC level (body text remains borrow-only, not accessed).

## What is asserted

- US 1955-56 domestic tour, 6 cities (Minneapolis → Pittsburgh) — \`src-moma-1955-press-release-book\`
- International edition first stop: Corcoran Gallery, Washington D.C., 30 Jun - 31 Jul 1955 — \`src-moma-1955-press-release-book\`
- USIA commissioning, multi-copy operational model, ~10 million visitors — \`src-cna-education\`, \`src-cna-collections-eng-family-of-man\`
- 4 verifiable international venues + Moscow year-only — image captions on \`src-cna-education\`
- 1992-94 pre-inscription touring (Toulouse, Tokyo, Hiroshima) — \`src-unesco-mow-2003\`
- "Last complete version" donation framing — \`src-cna-collections-deu-family-of-man\`

## What is openly flagged as unverified

- "9M visitors / 91 venues / 37 countries" headline aggregate — pending NARA RG 306 (two fetch attempts denied this round)
- Three-way end-date discrepancy: 1962 (CNA collections eng) vs 1964 (CNA education) vs 1965 (CNA Steichen-bio) — documented openly, no winner picked
- Moscow 1959 / Sokolniki / Kitchen Debate identification — plausible and widely repeated but not anchored in any source consulted for this wiki
- Turner 2013 and Sekula essays — named as standard critical references but explicitly flagged as not in repo and not consulted
- Sandeen 1995 body text — chapter titles only at ToC level
- Per-copy itinerary, country-level-only countries (India, France, Mexico, Germany, Australia, etc.), West Berlin reception — none asserted
- Disposition of the other 9 copies after the donated copy went to Luxembourg

## Validator audit

\`tvl-tech-bias-validator\` (sonnet) returned **REVISE** with two Groundedness FLAGs, both fixed before commit:

1. Sandeen chapter-titles attestation moved into \`src-sandeen-1995\` Key excerpts block (had been only in the research note).
2. Unsourced "USIA-curated jazz tours" clause dropped from the lead paragraph.

Other checks (Sycophancy, Confirmation, Anchoring, Scope creep): PASS.

## Test plan

- [ ] Schema judge: footnote refs balance with definitions; updated source-entry frontmatter conforms; Sandeen \`accessed:\` date update is well-formed.
- [ ] Credibility judge: every footnote names a source in \`sources/\`; tier compliance preserved.
- [ ] Grounding judge: spot-check footnoted quotes against updated Key excerpts blocks. Special attention to the four geo-located captions and the Sandeen chapter titles (both newly added to source entries this PR).
- [ ] Bias judge: institutional/curatorial perspective named in the perspective note; \`9M/91/37\` figure consistently treated as unverified throughout; three end-dates given equal weight without resolution; Turner/Sekula pointers not promoted to attestations; Cold War framing balanced against critical literature; no promotional voice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)