### PR TITLE
Bump research/mindmap.md and site/_data/progress.yml

### DIFF
--- a/research/mindmap.md
+++ b/research/mindmap.md
@@ -3,7 +3,7 @@ title: Research mindmap
 last_updated: 2026-04-29
 ---
 
-> **Note.** This document was last bumped on 2026-04-29 (10-day refresh from 2026-04-19). Catalog: **265 rows** (53% of 503), via PRs #4 (47), #7 (47), #11 (98), #16 (25), #49 (24), #53 (24). Photographers: 20 rows + 4 short bios + 20 source entries (PR #8 — re-verification of obit / museum-page citations still tracked under issue #9). Five overview pages are now substantive: `/exhibition/` (PR #41), `/clervaux/` (PR #43), `/unesco/` (PR #45), `/tour/` (PR #47), `/reception/` (PR #27). Live on the site.
+> **Note.** This document was last bumped on 2026-04-29 (10-day refresh from 2026-04-19). Catalog: **265 rows** (53% of 503), via PRs #4 (47), #7 (47), #11 (98), #16 (25), #49 (24), #53 (24). Photographers: 20 rows + 4 short bios + 20 source entries (PR #8). Issue #9 closed via PR #12 on 2026-04-24 — the re-verification pass concluded that **18 of 20** photographer-source files cannot be directly fetched (institutional 403s / paywalls) and remain `verified: false`. The access-barrier problem is real and ongoing, but is documented under "Methodological gaps" below, not under issue #9 (which is closed). Five overview pages are now substantive: `/exhibition/` (PR #41), `/clervaux/` (PR #43), `/unesco/` (PR #45), `/tour/` (PR #47), `/reception/` (PR #27). Live on the site.
 
 # Research mindmap
 
@@ -94,7 +94,7 @@ A living map of **what we know** (with sources) and **what we need to investigat
 
 ### Photographers — batch 1 seeded (PR #8)
 - **20 photographer rows** covering every unique individual named in the first 47 catalog plates. 4 short bios exist (Capa, Wayne Miller, Doisneau, DeCarava) — the remaining 16 are CSV rows only.
-- **20 source entries added** with `verified: false` flags (NYT obituaries, Magnum, ICP, CCP, Moderna Museet, etc.) because WebFetch returned 403 during the seed session. **Issue #9 still open** — the re-verification has not been done. This blocks more photographer batches.
+- **20 source entries added** with `verified: false` flags (NYT obituaries, Magnum, ICP, CCP, Moderna Museet, etc.) because WebFetch returned 403 during the seed session. **Issue #9 closed via PR #12** (2026-04-24): the re-verification pass *was done* and concluded that 18 of 20 sources still cannot be directly fetched. The access-barrier problem persists and constrains scaling more photographer batches; tracked under "Methodological gaps" below.
 - **Gender column blank** on all 20 rows per project tagging policy.
 
 ### World tour 1955–c.1962/1964/1965 *(substantive — PR #47)*
@@ -143,7 +143,7 @@ A living map of **what we know** (with sources) and **what we need to investigat
 - **Canonical 1955 catalog pages** for the headline figures (503/273/68) — currently anchored on three institutional summaries (MoMA Archives Highlights, UNESCO register, CNA collections page); a primary-source citation to specific pages of the 1955 catalog is still missing.
 
 ### P1 — core (phase 2)
-- **273 photographer biographies** — 4/273 done; 269 remain. Each needs dates, nationality, and a Tier-1/2 source. **Issue #9 still blocks** scaling this.
+- **273 photographer biographies** — 4/273 done; 269 remain. Each needs dates, nationality, and a Tier-1/2 source. The PR #8 re-verification pass (closed via PR #12) concluded that 18 of 20 batch-1 source URLs cannot be directly fetched — a persistent access-barrier problem (see "Methodological gaps" below) that constrains scaling further batches.
 - **NARA RG 306 (USIA records)** — the single most consequential gap for the world-tour aggregate (9M/91/37). Fetch attempts denied. A future pass should consult the RG 306 finding aid (Exhibits Division), per-copy / per-venue tour logs, and closing-administration date (which would resolve the 1962/1964/1965 end-date discrepancy).
 - **MoMA International Program records** — would close the per-copy disposition question (one copy went to Luxembourg as the donation; fates of the other nine copies unknown).
 - **Sandeen 1995 full text** — particularly the *"on the move"* and *"in Moscow"* chapters. CDL borrow not completed.
@@ -176,7 +176,7 @@ A living map of **what we know** (with sources) and **what we need to investigat
 
 ### Methodological gaps
 - **Theme-count reconciliation** — UNESCO 32, CNA 37, our 11. Cross-source treatment exists in `research/sections.md` but is not yet a published essay.
-- **WebFetch access to institutional archives** — MoMA / Magnum / ICP / NYT / NARA returned 403 across several sessions. Options: live audit pass with human-operated browser, archive.org snapshots, or a `gh api` / academic-library proxy. **Issue #9 still tracks.**
+- **WebFetch access to institutional archives** — MoMA / Magnum / ICP / NYT / NARA returned 403 across several sessions, including the dedicated re-verification pass under PR #12 (which concluded 18 of 20 PR #8 sources remained inaccessible). Options to unblock: live audit pass with human-operated browser, archive.org snapshots, or a `gh api` / academic-library proxy. **Issue #9 is closed; the underlying access-barrier problem is the open item.**
 - **Catalog-builder source-entry coverage** — the in-repo `src-moma-exh-0569-master-checklist` excerpt block covers Sections 1–7 only; the catalog rows beyond #50 cite the linked PDF (per the file's URL field) rather than verbatim Key excerpts. This is the established pattern (217+ rows so far) but worth eventually expanding into a comprehensive section-by-section source-entry transcription, particularly if the Tier-1 nomination flow strengthens further.
 
 ---
@@ -189,7 +189,7 @@ A living map of **what we know** (with sources) and **what we need to investigat
 | [#2](https://github.com/danlex/thefamilyofman/issues/2) | Thematic sections + prologue | `CLOSED` via PR #3 | Merged before judges; re-audit pending. |
 | [#5](https://github.com/danlex/thefamilyofman/issues/5) | Catalog plates 48–100 | `CLOSED` via PR #7 | +47 rows. |
 | [#6](https://github.com/danlex/thefamilyofman/issues/6) | Photographer bios batch 1 | `CLOSED` via PR #8 | 20 rows + 4 bios + 20 source entries. |
-| [#9](https://github.com/danlex/thefamilyofman/issues/9) | Re-verify PR #8 citations | `OPEN` | Blocks more photographer batches. |
+| [#9](https://github.com/danlex/thefamilyofman/issues/9) | Re-verify PR #8 citations | `CLOSED` via PR #12 | Re-verification pass done 2026-04-24; 18 of 20 sources remain `verified: false` due to access barriers. Underlying problem tracked in "Methodological gaps." |
 | [#10](https://github.com/danlex/thefamilyofman/issues/10) | Catalog plates 101–200 | `CLOSED` via PR #11 | +98 rows. |
 | [#15](https://github.com/danlex/thefamilyofman/issues/15) | Catalog plates 201–226 | `CLOSED` via PR #16 | +25 rows; pre-merge fixes from judge-bias and judge-grounding (photo-0201 character-type). |
 | [#27](https://github.com/danlex/thefamilyofman/issues/27) | /reception/ expansion | `CLOSED` via PR #27 | Substantive overview merged. |

--- a/research/mindmap.md
+++ b/research/mindmap.md
@@ -1,9 +1,9 @@
 ---
 title: Research mindmap
-last_updated: 2026-04-19
+last_updated: 2026-04-29
 ---
 
-> **Note.** This document was last bumped on 2026-04-19. Catalog: **192 rows** seeded (PRs #4 + #7 + #11). Photographers: 20 rows + 4 short bios + 20 source entries seeded (PR #8). Live on the site. An unresolved bottleneck: obituary and museum-page citations in PR #8 carry `verified: false` flags because WebFetch was denied by MoMA / Magnum / ICP / NYT — issue #9 tracks the re-verification.
+> **Note.** This document was last bumped on 2026-04-29 (10-day refresh from 2026-04-19). Catalog: **265 rows** (53% of 503), via PRs #4 (47), #7 (47), #11 (98), #16 (25), #49 (24), #53 (24). Photographers: 20 rows + 4 short bios + 20 source entries (PR #8 — re-verification of obit / museum-page citations still tracked under issue #9). Five overview pages are now substantive: `/exhibition/` (PR #41), `/clervaux/` (PR #43), `/unesco/` (PR #45), `/tour/` (PR #47), `/reception/` (PR #27). Live on the site.
 
 # Research mindmap
 
@@ -14,140 +14,160 @@ A living map of **what we know** (with sources) and **what we need to investigat
 <pre class="tree">
 <span class="tree-root">The Family of Man</span>
 │
-├─ <b>1955 Exhibition</b>
-│  ├─ Museum of Modern Art, New York
-│  ├─ Edward Steichen &mdash; curator
-│  ├─ Paul Rudolph &mdash; installation design
-│  ├─ Carl Sandburg &mdash; prologue
-│  └─ Opened 24 January 1955
+├─ <b>1955 Exhibition</b> &mdash; <i>see <a href="{{ '/exhibition/' | relative_url }}">/exhibition/</a></i>
+│  ├─ Museum of Modern Art, New York; 24 January &ndash; 8 May 1955
+│  ├─ Edward Steichen, curator (assisted by Wayne Miller)
+│  ├─ Paul Rudolph, installation design (temporary walls; print sizes 24&times;36 to 300&times;400&nbsp;cm)
+│  ├─ Carl Sandburg, prologue (leaflet at the entrance)
+│  ├─ ~270,000 NY visitors
+│  └─ Closing image: W. Eugene Smith, <i>A Walk to Paradise Garden</i> (1946)
 │
 ├─ <b>Catalog</b>
-│  ├─ 503 photographs
-│  ├─ 273 photographers
-│  ├─ 68 countries of origin
-│  └─ Selected from a large submission pool
-│     <i>(commonly cited as &ldquo;2 million&rdquo;; primary source not yet verified)</i>
+│  ├─ 503 photographs / 273 photographers / 68 countries
+│  ├─ 265 rows seeded (53%) &mdash; <i>see <a href="{{ '/photographs/' | relative_url }}">/photographs/</a></i>
+│  ├─ 11 individual missing plate numbers in the printed checklist (#5, #7, #8, #61, #88, #90, #145, #149, #216, #246, #261)
+│  └─ Selection process (~2&nbsp;million submissions commonly cited; primary source not yet verified)
 │
-├─ <b>World Tour 1955&ndash;1962</b>
-│  ├─ USIA sponsored
-│  ├─ ~91 venues
-│  ├─ 37 countries
-│  ├─ ~9 million visitors
-│  └─ Moscow 1959 &mdash; Sokolniki Park
+├─ <b>World Tour 1955&ndash;c.1962/1964/1965</b> &mdash; <i>see <a href="{{ '/tour/' | relative_url }}">/tour/</a></i>
+│  ├─ 1955&ndash;56 US 6-city tour (Minneapolis &rarr; Pittsburgh)
+│  ├─ International edition first stop: Corcoran Gallery, Washington D.C., 30 Jun&ndash;31 Jul 1955
+│  ├─ USIA commissioning: 10 copies, ~160 towns, ~10M visitors (per CNA)
+│  ├─ Verified abroad: Guatemala City 1955, Tokyo 1956, Johannesburg 1958, Moscow 1959 (year-only)
+│  ├─ Three-way end-date discrepancy: 1962 (CNA collections) vs 1964 (CNA education) vs 1965 (CNA bio)
+│  └─ 1992&ndash;94 second wave: Toulouse, Tokyo, Hiroshima (per UNESCO MoW register)
 │
-├─ <b>Clervaux, Luxembourg</b>
-│  ├─ Steichen&rsquo;s gift to his country of birth
-│  ├─ CNA &mdash; Centre national de l&rsquo;audiovisuel
-│  ├─ Permanent installation since 1994
-│  └─ Restoration 2010&ndash;2013
+├─ <b>Clervaux, Luxembourg</b> &mdash; <i>see <a href="{{ '/clervaux/' | relative_url }}">/clervaux/</a></i>
+│  ├─ 1964&ndash;66 US Government donation, at Steichen's request
+│  ├─ 1966 Steichen Clervaux visit (CNA: <i>"expresses his wish for permanent installation"</i>)
+│  ├─ 1974&ndash;89 partial exhibition at Clervaux Castle
+│  ├─ 1994 permanent installation (year only; curator unattested)
+│  ├─ 2010&ndash;13 second restoration: Studio Berselli, Milan + Nathalie Jacoby (NJOY) rooms
+│  └─ Custodian: Centre national de l'audiovisuel (CNA)
 │
-├─ <b>UNESCO 2003</b>
-│  └─ Memory of the World register
+├─ <b>UNESCO 2003</b> &mdash; <i>see <a href="{{ '/unesco/' | relative_url }}">/unesco/</a></i>
+│  ├─ Memory of the World programme (founded 1992; 14-member IAC; 570 inscriptions to April 2026)
+│  ├─ Submitted 2002 by Luxembourg; inscribed 2003
+│  ├─ Justification: <i>"greatest photographic enterprise"</i>; <i>"memory of an entire era, that of the Cold War and McCarthyism"</i>
+│  └─ Nomination-form PDFs linked but not yet read (URLs recorded)
 │
 ├─ <b>Thematic clusters</b> <i>(working reconstruction &mdash; see <a href="{{ '/sections/' | relative_url }}">/sections/</a>)</i>
-│  ├─ Prologue
-│  ├─ Lovers
-│  ├─ Marriage &amp; birth
-│  ├─ Family &amp; children
-│  ├─ Play &amp; learning
-│  ├─ Work
-│  ├─ Eating &amp; everyday
-│  ├─ Relationships
-│  ├─ Hardship &amp; war
-│  ├─ Death
-│  └─ Rededication
+│  ├─ 11 clusters covering 22 MoMA-numbered checklist sections
+│  ├─ UNESCO's "32 themes" / CNA's "37 themes" / our 11 clusters &mdash; documented discrepancy
+│  └─ 8 clusters now used in the catalog; <code>sec-eating-everyday</code> first used in PR #53
 │
-└─ <b>Critical reception</b>
-   ├─ Barthes 1957 &mdash; <i>The Great Family of Man</i>
+└─ <b>Critical reception</b> &mdash; <i>see <a href="{{ '/reception/' | relative_url }}">/reception/</a></i>
+   ├─ Barthes 1957 &mdash; <i>The Great Family of Man</i> (in repo, verbatim)
    ├─ Sontag 1977 &mdash; <i>On Photography</i>
-   ├─ Sekula 1981 &mdash; <i>The Traffic in Photographs</i>
-   ├─ Sandeen 1995 &mdash; <i>Picturing an Exhibition</i>
+   ├─ Sekula 1981 &mdash; <i>The Traffic in Photographs</i> (NOT in repo, named only)
+   ├─ Sandeen 1995 &mdash; <i>Picturing an Exhibition</i> (in repo; ToC visible, body borrow-only)
    ├─ Stimson 2006 &mdash; <i>The Pivot of the World</i>
-   └─ Turner 2013 &mdash; <i>The Democratic Surround</i>
+   └─ Turner 2013 &mdash; <i>The Democratic Surround</i> (NOT in repo, named only)
 </pre>
 
 ---
 
 ## What we know (with sources)
 
-### Exhibition — 1955 MoMA
-- **Opened 24 January 1955** at the Museum of Modern Art, New York. *Source: MoMA exhibition record #2429.*
-- **Curator: Edward Steichen**, then Director of MoMA's Department of Photography.
-- **Installation design: Paul Rudolph** (architect). *Source: MoMA Archives / archive-highlights page.*
-- **Prologue: Carl Sandburg** (Steichen's brother-in-law), distributed as a leaflet at the entrance.
-- **Scale: 503 photographs by 273 photographers from 68 countries.** *Citation status: not yet verified to pagination of the 1955 catalog in this repo; MoMA's public 2429 record is currently unreachable from our fetcher (confirmation needed before cite).*
-- **Selection process** — figure of "~2 million submissions" is commonly cited but **not yet verified**; Wikipedia's published figure of ~4 million refers to the *book* submission pool rather than the exhibition. Do not use either figure without a primary-source citation (1955 catalog or Steichen's writings).
-- **Entrance arch / crowd imagery opens the show.** *Source: MoMA archive-highlights page.*
-- **Closing image: W. Eugene Smith, *A Walk to Paradise Garden* (1946).** *Source: MoMA archive-highlights page.*
+### Exhibition — 1955 MoMA *(substantive — PR #41)*
+- **Opened 24 January 1955; closed 8 May 1955** at the Museum of Modern Art, New York. *Source: `src-moma-archives-highlights-1955`.*
+- **Curator: Edward Steichen, assisted by Wayne Miller.** *Source: same.*
+- **Installation design: Paul Rudolph** with temporary walls and print sizes ranging from **24 × 36 cm to 300 × 400 cm.** *Source: same.*
+- **Prologue: Carl Sandburg**, distributed as a leaflet at the entrance and reprinted in both editions of the catalog. *Source: `src-moma-1955-press-release-book`.*
+- **Two catalog editions published 21 June 1955** — deluxe ($10) and paper ($1) — both designed by Leo Lionni and printed by R.R. Donnelley. *Source: same.*
+- **Scale: 503 photographs by 273 photographers from 68 countries.** *Source: `src-moma-archives-highlights-1955`; cross-anchored on `src-unesco-mow-2003` and `src-cna-collections-eng-family-of-man`.*
+- **NY attendance: ~270,000.** *Source: `src-moma-archives-highlights-1955` (Relevance summary).*
+- **Closing image: W. Eugene Smith, *A Walk to Paradise Garden* (1946).** *Source: same.*
 
-### Thematic structure *(merged via PR #3)*
-- The 1955 catalog does **not** present a canonical numbered list of sections. Scholarly reconstructions differ: UNESCO Memory of the World register gives "32 themes" (confirmed). A "37 themes" figure is reported on CNA Luxembourg's education portal but is **not yet independently verified** in this repo (CNA site was unreachable during the 2026-04-19 audit).
-- **Our working reconstruction: 11 thematic clusters** (`sec-prologue` through `sec-rededication-future`) are live on the site under [/sections/](https://thefamilyofman.alexandrudan.com/sections/). Each row in `data/sections.csv` is tagged "thematic cluster reconstructed" to avoid implying canonical status.
-- **Governance note:** PR #3 was merged before the four-judge panel ran. The content should be re-audited — especially Judge-Grounding on the Barthes verbatim quotes and Judge-Bias on the theme-count treatment.
+### Thematic structure *(merged via PR #3; 8 of 11 clusters now used in catalog)*
+- The 1955 catalog does **not** present a canonical numbered list of sections. Three institutional figures circulate: UNESCO's **32 themes** (`src-unesco-mow-2003`), CNA's **37 themes** (`src-cna-education`), and our working reconstruction of **11 thematic clusters** (`sec-prologue` through `sec-rededication-future`). The discrepancy is recorded in `research/sections.md` and surfaced on `/sections/`.
+- **PR #53 first use of `sec-eating-everyday`** — Section 23 Food (#254-#268) maps to this cluster; this is the eighth cluster used in the catalog.
 
-### Catalog — first rows seeded (PR #4 open)
-- **New anchor source identified: MoMA Master Checklist for Exhibition #569** (`src-moma-exh-0569-master-checklist`, Tier 1). This 26-page internal checklist from MoMA Exhibitions is what PR #4 uses for every row — it gives per-plate photographer, agency/publication, nationality, "where taken," and print dimensions verbatim.
-- **Plate numbers skipped by the primary source so far:** #5, #7, #8 (Prologue); #61 (Mothers and Babies); #88, #90 (Family Activities); #145, #149 (Work A). Reasons not stated in the document. Each skip is noted in the adjacent row's `notes`.
-- **Out-of-order plates encountered in #101–200 range:** #115 opens Section 14 Land rather than closing Section 13; #168 appears mid-Section 14 between #141 and Section 15; #194 appears inside Section 19 Classical Music. Three-digit plates #505 and #506 also appear inside sections 14–15 (out of the 101–200 range) — deferred.
-- **Through plate #200 the checklist contains 192 photographs.** Our row ids `photo-0001`…`photo-0192` are sequential (we do not echo the skipped numbers).
-- **Joint-credit plates seeded:** #107 "Diane and Allan Arbus" (`photo-0101`); #173 "Fritz Goro with Robert Campbell" (`photo-0165`). Preserved as printed.
-- **The MoMA Master Checklist records no titles and no dates for individual plates.** Steichen deprived the images of titles (per CNA education portal). Plate years are absent from the primary source. Any year or title we add to a photograph row must be backed by a separate Tier-1/2 citation — secondary identifications (e.g., Bullock's *Let There Be Light* = plate 2) are preserved only in `notes` with a "reported, not primary-verified" caveat.
-- **The 7 subsections of the checklist** (Prologue, Lovers, Marriage, Pregnancy, Childbirth, Nursing Mothers, Births) map into 4 of our 11 thematic clusters (`sec-prologue`, `sec-lovers`, `sec-marriage-birth`, `sec-family-children`). Per-row mapping is documented in the CSV `notes` column.
-- **National attribution is preserved verbatim** from the checklist — Capa is listed "American," Erwitt "American," Horvat "Italian," even where later scholarly convention differs. Any re-framing is a separate editorial decision, not a silent correction.
+### Catalog — through plate #276 (265 rows, 53%)
+- **Anchor source: MoMA Master Checklist for Exhibition #569** (`src-moma-exh-0569-master-checklist`, Tier 1) — gives per-plate photographer, agency/publication, nationality, "where taken," and print dimensions verbatim.
+- **265 of 503 plates seeded** as of 2026-04-29, via PRs #4 (47), #7 (47), #11 (98), #16 (25), #49 (24), #53 (24). 238 plates remain.
+- **11 individual missing plate numbers** in the printed checklist, distributed across 7 distinct gap events: **#5, #7, #8** (Prologue); **#61** (Mothers and Babies); **#88, #90** (Family Activities); **#145, #149** (Work A); **#216** (Adult Play); **#246** (between Sections 21–22); **#261** (in Section 23 Food). Reasons not stated in the document. Each adjacent row's `notes` records the gap.
+- **Out-of-order plates documented**: #115 (Section 14 Land), #168 (Section 14 mid-flow), #194 (Section 19 Classical Music — Bischof at photo-0192), #269 (Section 25 Relationships — Ansel Adams at photo-0258, printed under the Section 25 heading on page 14 between #268 and #270). Three-digit plates #505 and #506 also appear inside sections 14–15 (deferred).
+- **Photographer-name OCR corrections (PR #51)**: photo-0210 'Nick de Morgol?' → 'Nick de Morgoli' (French Vogue photographer); photo-0216 'Walter Sanner' → 'Walter Sanders' (German-born American LIFE staff photographer 1944-1961). Both verified against MoMA's own artist database.
+- **Edward Steichen first appears as a plate photographer at #264 (photo-0253, Section 23 Food)** — a documented fact, not a curatorial-bias signal.
+- **The Master Checklist records no titles and no dates for individual plates.** Steichen deprived the images of titles. Any year or title we add must be backed by a separate Tier-1/2 citation; secondary identifications are preserved with "reported, not primary-verified" caveats.
+- **National attribution preserved verbatim** from the checklist — Capa "American," Erwitt "American," Horvat "Italian." Re-framing is a separate editorial decision, never a silent correction.
 
 ### Photographers — batch 1 seeded (PR #8)
 - **20 photographer rows** covering every unique individual named in the first 47 catalog plates. 4 short bios exist (Capa, Wayne Miller, Doisneau, DeCarava) — the remaining 16 are CSV rows only.
-- **Checklist nationality was preserved verbatim** — Capa "American," Horvat "Italian," Kessel "American" — with scholarly alternatives recorded in `notes`.
-- **20 new source entries were added** (NYT obituaries, a *Le Monde* obituary, Magnum Photos, ICP, CCP, Moderna Museet, Fotostiftung Schweiz). These are **Tier 3** and were added by author/publication/year because WebFetch to the institutional sites returned 403 during the seed session. Every citation carries a "verification flag for judges" note — Judge-Grounding re-verification is an open task (see issue #9 below).
-- **Gender is blank on all 20 rows** per the project's tagging policy.
+- **20 source entries added** with `verified: false` flags (NYT obituaries, Magnum, ICP, CCP, Moderna Museet, etc.) because WebFetch returned 403 during the seed session. **Issue #9 still open** — the re-verification has not been done. This blocks more photographer batches.
+- **Gender column blank** on all 20 rows per project tagging policy.
 
-### World tour 1955–1962
-- **Sponsor: United States Information Agency (USIA).** Records held at National Archives, RG 306.
-- **Commonly cited figures: ~91 venues, ~37 countries, ~9M visitors.** *Citation status: widely repeated but not yet verified to Tier-1 primary records in this repo.*
-- **Notable stop: Moscow 1959 (Sokolniki Park, American National Exhibition).** *Citation status: attested, not yet formally sourced in this repo.*
+### World tour 1955–c.1962/1964/1965 *(substantive — PR #47)*
+- **USIA commissioning attribution** verbatim: *"Commissioned by the USIA (United States Information Agency), an American governmental unit created during the Cold War to promote a positive image of the United States in front of the Russian propaganda."* *Source: `src-cna-education` (re-verified 2026-04-29).*
+- **1955–56 US domestic 6-city tour**: Minneapolis → Dallas → Cleveland → Philadelphia → Baltimore → Pittsburgh, Jun 1955 – Nov 1956. *Source: `src-moma-1955-press-release-book` p. 2.*
+- **International edition first stop**: Corcoran Gallery, Washington D.C., 30 Jun – 31 Jul 1955 (preceding Minneapolis by nine days). *Source: same.*
+- **Multi-copy operational model**: *"ten copies with minor changes sent to nearly 160 towns. Each of the copies was weighing one tonne and a half, was packed in twenty-three crates and required more than six days to be mounted/installed."* *Source: `src-cna-education`.*
+- **Verifiable international venues** (image captions on CNA portal): Palacio Protocolo, Guatemala City, 24 Aug – 18 Sept 1955; Takashimaya Department Store, Tokyo, March – April 1956; Government Pavilion, Johannesburg, 30 Aug – 13 Sept 1958; Moscow, USSR, 1959 (year-only). *Source: `src-cna-education`.*
+- **Aggregate attendance**: ~10 million per CNA (both English collections page and education portal); ~9 million widely cited in secondary literature. The 91 venues / 37 countries figure is unverified pending NARA RG 306 (USIA records).
+- **Three-way end-date discrepancy** (all CNA-published Tier 1): **1962** (`src-cna-collections-eng-family-of-man`), **1964** (`src-cna-education`), **1965** (`src-cna-edu-steichen-bio`). Documented openly; no winner picked without primary archival evidence.
+- **1992–94 second tour wave**: restored versions touring internationally — Toulouse, Tokyo, Hiroshima named. *Source: `src-unesco-mow-2003` (re-verified 2026-04-29).*
+- **Sandeen 1995 chapter titles** *"The family of man on the move"* and *"The family of man in Moscow"* confirmed at ToC level via Internet Archive; body text borrow-only and not accessed. *Source: `src-sandeen-1995` (Internet Archive ToC re-verification 2026-04-29).*
 
-### Clervaux (Luxembourg)
-- **Permanent installation since 1994** at Clervaux Castle.
-- **Custodian: Centre national de l'audiovisuel (CNA).** *Source: steichencollections.lu; cna.public.lu.*
-- **Restoration campaign: 2010–2013.** *Citation status: reported by CNA, not yet formally sourced in this repo.*
-- **Inscribed on UNESCO Memory of the World: 2003.** *Source: UNESCO register.*
+### Clervaux (Luxembourg) *(substantive — PR #43)*
+- **1964–66 donation**: US Government donates *"the last complete version of the travelling exhibition"* to Luxembourg at Steichen's request. *Source: `src-cna-collections-eng-family-of-man` and `src-cna-collections-deu-family-of-man`.*
+- **1966 Steichen Clervaux visit**: *"Edward Steichen visits his native country and expresses his wish for 'The Family of Man' to be exhibited permanently at Clervaux Castle."* *Source: `src-cna-collections-eng-family-of-man`.*
+- **1963 White House meeting** with Grand Duchess Charlotte / *"I am a Luxembourgish boy"* / 1966 *"ideal place"* remark — Tier 3 only (`src-chronicle-lu-2025-cercle-cite-steichen`); not anchored to Tier 1 archives in this round.
+- **1974–89 partial exhibition** at Clervaux Castle. *Source: `src-cna-collections-eng-family-of-man`.*
+- **1994 permanent installation** (year only — exact date and curator of record not on either CNA collections page consulted). *Source: same.*
+- **2010–13 second restoration**: closure September 2010, reopening July 2013. Conservation team: **Studio Berselli, Milan** (Silvia Berselli, Roberta Piantavigna, Francesca Vantellini, Isabel Dimas). Renovated rooms designed by **Nathalie Jacoby (NJOY)**. *Source: `src-cna-collections-eng-family-of-man`.*
+- **Custodian: Centre national de l'audiovisuel (CNA).** *Source: `steichencollections-cna.lu`.*
 
-### Critical reception — major landmarks
-- **Roland Barthes, "The Great Family of Man"** (in *Mythologies*, 1957). Foundational critique: universalist humanism flattens history and politics. *Verbatim text extracted from a university-hosted PDF via PR #3.*
+### UNESCO Memory of the World *(substantive — PR #45)*
+- **Memory of the World programme founded 1992**; 14-member International Advisory Committee appointed by UNESCO's Director-General; two-step inscription pathway (IAC recommendation + Executive Board endorsement); 2015 UNESCO Recommendation Concerning Preservation of, and Access to, Documentary Heritage. *Source: `src-unesco-mow-programme`.*
+- **2003 inscription**: registration year 2003, submission year **2002** by **Luxembourg**; region Europe and North America; document type "Books." *Source: `src-unesco-mow-2003` (re-verified 2026-04-29).*
+- **Justification language carried on register**: *"503 photographs taken by 273 photographers... from 68 countries"*; *"32 themes, arranged chronologically"*; *"Regarded as the 'greatest photographic enterprise ever undertaken'"*; *"the memory of an entire era, that of the Cold War and McCarthyism."* *Source: same.*
+- **570 inscribed items** on the International Register as of 2026-04-29 fetch. *Source: `src-unesco-mow-programme`.*
+- **Nomination form PDFs** (English and French) linked from the register page; URLs recorded in `src-unesco-mow-2003`; **content not read in any session so far** (access denied).
+
+### Critical reception — major landmarks *(substantive — PR #27 + PR #43/#47 cross-references)*
+- **Roland Barthes, "The Great Family of Man"** (in *Mythologies*, 1957). Foundational critique. *Source: `src-barthes-1957` (verbatim text via PR #3).*
 - **Susan Sontag, *On Photography*** (1977). Related sentimentalism critique.
-- **Allan Sekula, "The Traffic in Photographs"** — Marxist ideological reading. *Citation status: widely attributed to* Art Journal *1981, but volume/issue/pages are not yet verified in this repo.*
-- **Eric Sandeen, *Picturing an Exhibition: The Family of Man and 1950s America*** (U. New Mexico Press, 1995). Standard historical study; complicates both defense and critique.
+- **Allan Sekula, "The Traffic in Photographs"** *Art Journal* 1981 — Marxist ideological reading. **NOT in repo, not consulted; named only as pointer.**
+- **Eric Sandeen, *Picturing an Exhibition: The Family of Man and 1950s America*** (U. New Mexico Press, 1995). Standard historical study. *Source: `src-sandeen-1995` (review-metadata + ToC level only).*
 - **Blake Stimson, *The Pivot of the World*** (MIT Press, 2006). Re-reads the show within post-war photographic modernism.
-- **Fred Turner, *The Democratic Surround*** (U. Chicago Press, 2013). Liberal-democratic design culture.
+- **Fred Turner, *The Democratic Surround*** (U. Chicago Press, 2013). Liberal-democratic design culture. **NOT in repo, not consulted; named only as pointer.**
 
 ---
 
 ## What we need to investigate (prioritized gaps)
 
 ### P0 — foundational (blocks everything else)
-- **Catalog — plates 201–end** (after PR #11 the first 192 rows are seeded). Continue with the remainder of the MoMA Master Checklist #569; also record the out-of-range three-digit plates (#505, #506) that appeared early inside sections 14–15.
-- **Plate titles and dates** — the Master Checklist has neither. We need the *printed 1955 catalog* (the book) or Steichen's curatorial correspondence to attach titles and years to plates. Expected primary source: the Luxembourg National Library or a Google Books preview of the catalog; the Internet Archive scans were access-restricted.
-- **Verbatim Sandburg prologue text with page numbers.** Same blocker as above — access to a scan of the 1955 catalog.
-- **Canonical source for exhibition-level figures** (503, 273, 68, ~2M submissions) traced to specific pages of the 1955 catalog, not MoMA's summary pages.
+- **Catalog plates 277–end** — 238 plates remain after PR #53. Continue with the MoMA Master Checklist; also catalog the out-of-range three-digit plates (#505, #506).
+- **Plate titles and dates** — the Master Checklist has neither. Need the *printed 1955 catalog* (the book) or Steichen's curatorial correspondence. Expected primary source: the Luxembourg National Library or a non-restricted scan.
+- **Verbatim Sandburg prologue text with page numbers** — same blocker.
+- **Canonical 1955 catalog pages** for the headline figures (503/273/68) — currently anchored on three institutional summaries (MoMA Archives Highlights, UNESCO register, CNA collections page); a primary-source citation to specific pages of the 1955 catalog is still missing.
 
 ### P1 — core (phase 2)
-- **273 photographer biographies.** Each needs dates, nationality, and a Tier-1/2 source for inclusion.
-- **1955 installation specifics** — photograph sizes, layout, visitor flow. Paul Rudolph's drawings at MoMA Archives.
-- **Opening reception** — contemporary reviews in *New York Times*, *Art News*, *Aperture*, 1955–56. Attendance figures for the MoMA run.
-- **World tour venue-by-venue list** — venues, host institutions, dates, attendance. Primary source: USIA records, National Archives RG 306.
-- **Moscow 1959** — confirm dates, location (Sokolniki), visitor figures, press reception.
-- **Luxembourg provenance chain** — Steichen's deed of gift (date and terms), storage before 1994, exact 1994 opening details.
-- **2010–13 restoration** — lead conservator(s), techniques, scope, funding source.
-- **UNESCO nomination file (2003)** — text of the inscription and justification.
+- **273 photographer biographies** — 4/273 done; 269 remain. Each needs dates, nationality, and a Tier-1/2 source. **Issue #9 still blocks** scaling this.
+- **NARA RG 306 (USIA records)** — the single most consequential gap for the world-tour aggregate (9M/91/37). Fetch attempts denied. A future pass should consult the RG 306 finding aid (Exhibits Division), per-copy / per-venue tour logs, and closing-administration date (which would resolve the 1962/1964/1965 end-date discrepancy).
+- **MoMA International Program records** — would close the per-copy disposition question (one copy went to Luxembourg as the donation; fates of the other nine copies unknown).
+- **Sandeen 1995 full text** — particularly the *"on the move"* and *"in Moscow"* chapters. CDL borrow not completed.
+- **Turner 2013** *(The Democratic Surround)* and **Sekula's essays** — not in repo; future entries under `sources/2010s/` and `sources/1980s/`.
+- **Moscow 1959 detail** — confirm Sokolniki Park / American National Exhibition identification, dates, attendance, press reception. Eisenhower Presidential Library holdings would be the natural primary source.
+- **1994 Clervaux inauguration detail** — exact date, curator of record, installation design, opening programme. *Luxemburger Wort* and *Tageblatt* press archives, or a CNA press release of the day.
+- **1964–1974 storage decade** — where the prints physically lived between donation and the 1974 partial-display opening at Clervaux. Luxembourg cultural-affairs ministry archives.
+- **The "first" restoration phase** — implied by the German page's *"second restoration phase 2010–13"* wording. Date, scope, conservator-of-record all unattested.
+- **2010–13 conservation methodology** — Studio Berselli's published record + CNA annual reports for the period.
+- **1992–94 second-wave full itinerary** — UNESCO register names Toulouse, Tokyo, Hiroshima as a sample; the full venue list would be in CNA records.
+- **UNESCO nomination form PDFs (2002)** — both English and French; URLs recorded in `src-unesco-mow-2003` but access denied. The formal IAC justification text submitted in 2002 is the strongest available primary source for the inscription's stated rationale.
+- **2013 and 2023 UNESCO inscription anniversary events** — no records consulted; CNA annual reports + Luxembourg cultural press are the natural sources.
+- **1963 Charlotte / Steichen meeting** — currently rests on Tier 3 only (`src-chronicle-lu-2025-cercle-cite-steichen`). Verifiable against Cour grand-ducale or U.S. State Department diplomatic records.
+- **1955 installation photographs** — Paul Rudolph's drawings at MoMA Archives.
+- **Opening reception** — contemporary reviews in *NYT*, *Art News*, *Aperture*, 1955–56.
 - **Critical reception in non-English scholarship** — French and German writing, especially from Clervaux-era CNA.
 
 ### P2 — enrichment (phase 3)
 - **Per-photograph provenance** for each of the 503 — one article per photograph.
 - **Photographer compensation and consent** arrangements.
-- **Selection process** — how 2M submissions were cut to 503 (Wayne Miller's role as Steichen's assistant).
+- **Selection process** — how the submission pool was cut to 503 (Wayne Miller's role).
 - **Exhibition funding and sponsorship** in 1955.
 - **Current CNA curatorial practice** — rotation schedule, loans, ongoing conservation.
-- **Anniversary events** — 50th (2005), 60th (2015), 70th (2025).
+- **Anniversary events** — 50th (2005), 60th (2015), 70th (2025) of the original 1955 opening.
 
 ### Language gaps
 - **Francophone scholarship** (CNA publications, *Revue des musées de France*, French press 1994–present).
@@ -155,22 +175,32 @@ A living map of **what we know** (with sources) and **what we need to investigat
 - **Luxembourgish-language coverage** of Clervaux.
 
 ### Methodological gaps
-- **Theme-count reconciliation** — UNESCO says 32, CNA says 37, our reconstruction proposes 11. Need a source-by-source treatment.
-- **Attribution practice** — where our row cites multiple sources with semicolons, confirm CSV-reader compatibility with all tools (not just `validate_schema.py`).
-- **WebFetch access to institutional archives** — MoMA (`moma.org`), Magnum (`magnumphotos.com`), ICP (`icp.org`), and NYT all returned 403 to our automated fetcher during the PR #8 session. Source entries added in that PR carry *unverified* permalinks. Options to unblock: (a) a live audit pass with a human-operated browser, (b) a cross-mirror reader (archive.org snapshot or `archive.today`), (c) a `gh api` or academic-library proxy path. Until this is resolved, avoid adding more photographer-bio batches that depend on web-fetched institutional pages.
+- **Theme-count reconciliation** — UNESCO 32, CNA 37, our 11. Cross-source treatment exists in `research/sections.md` but is not yet a published essay.
+- **WebFetch access to institutional archives** — MoMA / Magnum / ICP / NYT / NARA returned 403 across several sessions. Options: live audit pass with human-operated browser, archive.org snapshots, or a `gh api` / academic-library proxy. **Issue #9 still tracks.**
+- **Catalog-builder source-entry coverage** — the in-repo `src-moma-exh-0569-master-checklist` excerpt block covers Sections 1–7 only; the catalog rows beyond #50 cite the linked PDF (per the file's URL field) rather than verbatim Key excerpts. This is the established pattern (217+ rows so far) but worth eventually expanding into a comprehensive section-by-section source-entry transcription, particularly if the Tier-1 nomination flow strengthens further.
 
 ---
 
 ## Active investigations
 
-| # | Title | State | Agent | Notes |
-|---|---|---|---|---|
-| [#1](https://github.com/danlex/thefamilyofman/issues/1) | Catalog plates 1–50 | `CLOSED` via PR #4 | catalog-builder | 47 rows merged; MoMA Master Checklist #569 added as Tier-1 anchor. Judge panel not run. |
-| [#2](https://github.com/danlex/thefamilyofman/issues/2) | Thematic sections + prologue | `CLOSED` via PR #3 | sections-cartographer | Merged without judge review — re-audit pending. |
-| [#5](https://github.com/danlex/thefamilyofman/issues/5) | Catalog plates 48–100 | `CLOSED` via PR #7 | catalog-builder | 47 further rows merged (plate numbers 51–100, checklist-skipped #61, #88, #90). |
-| [#6](https://github.com/danlex/thefamilyofman/issues/6) | Photographer bios batch 1 | `CLOSED` via PR #8 | photographer-biographer | 20 rows + 4 bios + 20 source entries merged. Obit/museum citations carry "not re-verified" flags — follow-up below. |
-| [#9](https://github.com/danlex/thefamilyofman/issues/9) | Re-verify PR #8 citations | `needs-agent` | sources-librarian | Re-fetch the 20 source files via live + archive.org; mark `verified: true/false`. Blocks more photographer batches. |
-| [#10](https://github.com/danlex/thefamilyofman/issues/10) | Catalog plates 101–200 | `CLOSED` via PR #11 | catalog-builder | 98 rows merged (`photo-0095`…`photo-0192`); skipped #145, #149; out-of-order #115, #168, #194. |
+| # | Title | State | Notes |
+|---|---|---|---|
+| [#1](https://github.com/danlex/thefamilyofman/issues/1) | Catalog plates 1–50 | `CLOSED` via PR #4 | 47 rows. |
+| [#2](https://github.com/danlex/thefamilyofman/issues/2) | Thematic sections + prologue | `CLOSED` via PR #3 | Merged before judges; re-audit pending. |
+| [#5](https://github.com/danlex/thefamilyofman/issues/5) | Catalog plates 48–100 | `CLOSED` via PR #7 | +47 rows. |
+| [#6](https://github.com/danlex/thefamilyofman/issues/6) | Photographer bios batch 1 | `CLOSED` via PR #8 | 20 rows + 4 bios + 20 source entries. |
+| [#9](https://github.com/danlex/thefamilyofman/issues/9) | Re-verify PR #8 citations | `OPEN` | Blocks more photographer batches. |
+| [#10](https://github.com/danlex/thefamilyofman/issues/10) | Catalog plates 101–200 | `CLOSED` via PR #11 | +98 rows. |
+| [#15](https://github.com/danlex/thefamilyofman/issues/15) | Catalog plates 201–226 | `CLOSED` via PR #16 | +25 rows; pre-merge fixes from judge-bias and judge-grounding (photo-0201 character-type). |
+| [#27](https://github.com/danlex/thefamilyofman/issues/27) | /reception/ expansion | `CLOSED` via PR #27 | Substantive overview merged. |
+| [#41](https://github.com/danlex/thefamilyofman/issues/41) | /exhibition/ expansion | `CLOSED` via PR #41 | Substantive overview merged. |
+| [#42](https://github.com/danlex/thefamilyofman/issues/42) | /clervaux/ expansion | `CLOSED` via PR #43 | Substantive overview; new source `src-cna-collections-eng-family-of-man`. |
+| [#44](https://github.com/danlex/thefamilyofman/issues/44) | /unesco/ expansion | `CLOSED` via PR #45 | Substantive overview; new source `src-unesco-mow-programme`. |
+| [#46](https://github.com/danlex/thefamilyofman/issues/46) | /tour/ expansion | `CLOSED` via PR #47 | Substantive overview; three source entries updated. |
+| [#48](https://github.com/danlex/thefamilyofman/issues/48) | Catalog batch #227–251 | `CLOSED` via PR #49 | +24 rows (gap at #246). |
+| [#50](https://github.com/danlex/thefamilyofman/issues/50) | Photo-0210 / photo-0216 name corrections | `CLOSED` via PR #51 | OCR-error corrections verified against MoMA artist database. |
+| [#52](https://github.com/danlex/thefamilyofman/issues/52) | Catalog batch #252–276 | `CLOSED` via PR #53 | +24 rows (gap at #261); first use of `sec-eating-everyday`. |
+| [#54](https://github.com/danlex/thefamilyofman/issues/54) | Bump mindmap + progress.yml | `OPEN` | This PR. |
 
 ---
 

--- a/scripts/compute_progress.sh
+++ b/scripts/compute_progress.sh
@@ -40,8 +40,8 @@ cat > "$OUT" <<YAML
 
 exhibition:
   kind: status
-  label: "outline"
-  note: "Placeholder — historian not yet dispatched."
+  label: "substantive"
+  note: "Substantive overview merged via PR #41 (24 January – 8 May 1955 MoMA opening; Steichen + Wayne Miller; Paul Rudolph installation; Sandburg prologue; arc of the show; reception thread)."
 
 photographs:
   kind: count
@@ -67,18 +67,23 @@ sections:
 
 tour:
   kind: status
-  label: "outline"
-  note: "Placeholder — historian not yet dispatched."
+  label: "substantive"
+  note: "Substantive overview merged via PR #47 (1955-56 US 6-city tour; USIA international tour 1955-c.1962/1964/1965; Corcoran/Guatemala/Tokyo/Johannesburg/Moscow venues attested; 1992-94 second wave Toulouse/Tokyo/Hiroshima; Cold War cultural-diplomacy framing). Headline aggregate (9M/91/37) pending NARA RG 306."
 
 clervaux:
   kind: status
-  label: "outline"
-  note: "Placeholder — historian not yet dispatched."
+  label: "substantive"
+  note: "Substantive overview merged via PR #43 (1964-66 donation; 1974-89 partial display; 1994 permanent installation; September 2010 → July 2013 second restoration with Studio Berselli + NJOY rooms; current CNA curation)."
+
+unesco:
+  kind: status
+  label: "substantive"
+  note: "Substantive overview merged via PR #45 (1992 Memory of the World programme; IAC + Executive Board pathway; 2002 submission by Luxembourg, 2003 inscription; 32-themes register count; 1992-94 pre-inscription touring; what inscription does and does not entail)."
 
 reception:
   kind: status
-  label: "outline"
-  note: "Major landmarks listed; essay pending."
+  label: "substantive"
+  note: "Substantive overview merged via PR #27 (Barthes 1957, Sontag 1977, Sekula 1981, Sandeen 1995, Stimson 2006, Turner 2013 framework). Tier 1-2 critical anchors in place; full critical-reception article."
 
 bibliography:
   kind: count

--- a/site/_data/progress.yml
+++ b/site/_data/progress.yml
@@ -3,15 +3,15 @@
 
 exhibition:
   kind: status
-  label: "outline"
-  note: "Placeholder — historian not yet dispatched."
+  label: "substantive"
+  note: "Substantive overview merged via PR #41 (24 January – 8 May 1955 MoMA opening; Steichen + Wayne Miller; Paul Rudolph installation; Sandburg prologue; arc of the show; reception thread)."
 
 photographs:
   kind: count
-  count: 217
+  count: 265
   total: 503
-  pct: 43
-  label: "217 / 503  ·  43%"
+  pct: 52
+  label: "265 / 503  ·  52%"
 
 photographers:
   kind: count
@@ -30,23 +30,28 @@ sections:
 
 tour:
   kind: status
-  label: "outline"
-  note: "Placeholder — historian not yet dispatched."
+  label: "substantive"
+  note: "Substantive overview merged via PR #47 (1955-56 US 6-city tour; USIA international tour 1955-c.1962/1964/1965; Corcoran/Guatemala/Tokyo/Johannesburg/Moscow venues attested; 1992-94 second wave Toulouse/Tokyo/Hiroshima; Cold War cultural-diplomacy framing). Headline aggregate (9M/91/37) pending NARA RG 306."
 
 clervaux:
   kind: status
-  label: "outline"
-  note: "Placeholder — historian not yet dispatched."
+  label: "substantive"
+  note: "Substantive overview merged via PR #43 (1964-66 donation; 1974-89 partial display; 1994 permanent installation; September 2010 → July 2013 second restoration with Studio Berselli + NJOY rooms; current CNA curation)."
+
+unesco:
+  kind: status
+  label: "substantive"
+  note: "Substantive overview merged via PR #45 (1992 Memory of the World programme; IAC + Executive Board pathway; 2002 submission by Luxembourg, 2003 inscription; 32-themes register count; 1992-94 pre-inscription touring; what inscription does and does not entail)."
 
 reception:
   kind: status
-  label: "outline"
-  note: "Major landmarks listed; essay pending."
+  label: "substantive"
+  note: "Substantive overview merged via PR #27 (Barthes 1957, Sontag 1977, Sekula 1981, Sandeen 1995, Stimson 2006, Turner 2013 framework). Tier 1-2 critical anchors in place; full critical-reception article."
 
 bibliography:
   kind: count
-  count: 31
-  label: "31 source entries  ·  growing"
+  count: 36
+  label: "36 source entries  ·  growing"
 
 mindmap:
   kind: status


### PR DESCRIPTION
Closes #54.

## Summary

Tracking-layer refresh PR. The mindmap was 10 days behind merged work; the homepage progress indicators were calling four substantive pages 'placeholders'.

- \`research/mindmap.md\` (REWRITE) — 3,200 words, refreshed for PRs #41, #43, #45, #47, #49, #51, #53 + the missing PR #16 from before this session
- \`site/_data/progress.yml\` (REGENERATED) — five overview pages now 'substantive'; new \`unesco\` entry; counts updated (265/503 photographs, 36 sources)
- \`scripts/compute_progress.sh\` (UPDATED) — hardcoded status labels updated to reflect actual state of overview pages

## Validator audit

\`tvl-tech-bias-validator\` (sonnet) returned **BLOCK** on two internal-consistency issues, both fixed before commit:
1. Gap-count label said 'Six documented numbering gaps' but enumerated 11 individual missing numbers across 7 events. Standardised to '11 individual missing plate numbers across 7 distinct gap events.'
2. Per-PR row breakdown summed to 240, not 265. Identified the missing PR #16 (#15, plates 201-226, 25 rows) and added it to both the per-PR breakdown and the Active Investigations table.

Other 4 checks (Sycophancy, Confirmation, Anchoring, Scope creep): PASS.

## Test plan

- [ ] Schema judge: validate_schema, check_credibility (now 36/36, was 36/35), injection-scan
- [ ] Credibility judge: every source-id mentioned exists; no rejected source types
- [ ] Grounding judge: spot-check the 'what we know' claims against either the cited source-id's Key excerpts or the corresponding merged PR's diff. Special attention to: PR-breakdown arithmetic (47+47+98+25+24+24=265); five 'substantive' pages confirmed substantive; gap enumeration matches between Overview tree and What We Know section
- [ ] Bias judge: tracking-layer accuracy; honest 'still gap' vs 'partially resolved' distinctions; no overstatement of page substantive-ness; PR/issue numbers in Active Investigations table consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)