### PR TITLE
Add tour map visualisation to /tour/

### DIFF
--- a/site/_data/tour_venues.yml
+++ b/site/_data/tour_venues.yml
@@ -61,9 +61,10 @@ venues:
     lat: 39.33
     lon: -76.62
     venue: Baltimore Museum of Art
-    dates: "30 May – 15 Jul 1956"
+    dates: "30 May – 15 Jul 1956 (approx.)"
     wave: us-domestic
     source: src-moma-1955-press-release-book
+    note: "The MoMA press release records this venue's dates with an explicit '(approx.)' qualifier."
 
   - city: Pittsburgh
     country: USA

--- a/site/_data/tour_venues.yml
+++ b/site/_data/tour_venues.yml
@@ -1,0 +1,161 @@
+# Verified tour venues for The Family of Man, used by site/_includes/tour-map.html
+# and embedded on /tour/.
+#
+# Provenance: every venue listed below is attested in an in-repo source-entry's
+# Key excerpts block (src-moma-1955-press-release-book, src-cna-education, or
+# src-unesco-mow-2003). Speculative venues, country-level-only mentions without
+# specific city/dates, and venues attested only in secondary literature are NOT
+# listed here.
+#
+# Coordinates: city centroids from general geographic knowledge — they are NOT
+# claimed to be source-corroborated, only approximate placement for
+# visualization. Specific tour-venue addresses (e.g., the Corcoran Gallery's
+# 17th & New York Ave NW location) are not separately recorded; city-level
+# placement is sufficient for the multi-continent visualization.
+#
+# Three tour waves are color-coded:
+#   us-domestic            — 1955-56, 6 cities, MoMA International Program
+#   international-1955-65  — 1955 onward, USIA-commissioned, multi-copy circulation
+#   second-wave-1992-94    — restored versions touring before 1994 Clervaux install
+
+venues:
+  # 1955-56 US domestic tour - all attested in src-moma-1955-press-release-book p. 2
+  - city: Minneapolis
+    country: USA
+    lat: 44.97
+    lon: -93.27
+    venue: Minneapolis Institute of Art
+    dates: "21 Jun – 4 Sept 1955"
+    wave: us-domestic
+    source: src-moma-1955-press-release-book
+
+  - city: Dallas
+    country: USA
+    lat: 32.78
+    lon: -96.80
+    venue: Dallas Museum of Fine Arts
+    dates: "7 Oct – 18 Nov 1955"
+    wave: us-domestic
+    source: src-moma-1955-press-release-book
+
+  - city: Cleveland
+    country: USA
+    lat: 41.50
+    lon: -81.69
+    venue: Cleveland Museum of Art
+    dates: "24 Jan – 5 Mar 1956"
+    wave: us-domestic
+    source: src-moma-1955-press-release-book
+
+  - city: Philadelphia
+    country: USA
+    lat: 39.96
+    lon: -75.18
+    venue: Philadelphia Museum of Art
+    dates: "25 Mar – 29 Apr 1956"
+    wave: us-domestic
+    source: src-moma-1955-press-release-book
+
+  - city: Baltimore
+    country: USA
+    lat: 39.33
+    lon: -76.62
+    venue: Baltimore Museum of Art
+    dates: "30 May – 15 Jul 1956"
+    wave: us-domestic
+    source: src-moma-1955-press-release-book
+
+  - city: Pittsburgh
+    country: USA
+    lat: 40.44
+    lon: -79.99
+    venue: Carnegie Institute
+    dates: "18 Oct – 29 Nov 1956"
+    wave: us-domestic
+    source: src-moma-1955-press-release-book
+
+  # International edition / USIA tour 1955-c.1965
+  - city: Washington D.C.
+    country: USA
+    lat: 38.91
+    lon: -77.04
+    venue: Corcoran Gallery
+    dates: "30 Jun – 31 Jul 1955"
+    wave: international-1955-65
+    source: src-moma-1955-press-release-book
+    note: "International edition first stop, preceding Minneapolis by nine days."
+
+  - city: Guatemala City
+    country: Guatemala
+    lat: 14.63
+    lon: -90.51
+    venue: Palacio Protocolo
+    dates: "24 Aug – 18 Sept 1955"
+    wave: international-1955-65
+    source: src-cna-education
+
+  - city: Tokyo
+    country: Japan
+    lat: 35.68
+    lon: 139.76
+    venue: Takashimaya Department Store
+    dates: "March – April 1956"
+    wave: international-1955-65
+    source: src-cna-education
+
+  - city: Johannesburg
+    country: Union of South Africa
+    lat: -26.20
+    lon: 28.04
+    venue: Government Pavilion
+    dates: "30 Aug – 13 Sept 1958"
+    wave: international-1955-65
+    source: src-cna-education
+
+  - city: Moscow
+    country: USSR
+    lat: 55.75
+    lon: 37.62
+    venue: ""
+    dates: "1959 (year only)"
+    wave: international-1955-65
+    source: src-cna-education
+    note: "Venue and exact dates not on the source caption; Sokolniki Park / American National Exhibition identification widely cited but unanchored in any in-repo source."
+
+  # 1992-94 second wave (restored versions touring) - src-unesco-mow-2003
+  - city: Toulouse
+    country: France
+    lat: 43.60
+    lon: 1.44
+    venue: ""
+    dates: "1992 / 1993–94"
+    wave: second-wave-1992-94
+    source: src-unesco-mow-2003
+
+  - city: Tokyo
+    country: Japan
+    lat: 35.68
+    lon: 139.76
+    venue: ""
+    dates: "1992 / 1993–94"
+    wave: second-wave-1992-94
+    source: src-unesco-mow-2003
+    note: "Same city as the 1956 USIA stop; second-wave touring revisited."
+
+  - city: Hiroshima
+    country: Japan
+    lat: 34.39
+    lon: 132.45
+    venue: ""
+    dates: "1992 / 1993–94"
+    wave: second-wave-1992-94
+    source: src-unesco-mow-2003
+
+# Country-level mentions on src-cna-education that do NOT resolve to a specific
+# city/venue/dates are not plotted. Per the CNA portal, these countries appear
+# in the open-ended sample list "India, Russia, France, Zimbabwe, South Africa,
+# Mexico, Germany, Japan, Australia" — six of those nine countries (India,
+# France-non-Toulouse, Mexico, Germany, Australia, and the historically-
+# anachronistic "Zimbabwe" for what was Southern Rhodesia 1955-65) have no
+# city-level attestation in any in-repo source. Future research passes (NARA
+# RG 306, MoMA International Program records) would supply specific venues.

--- a/site/_includes/tour-map.html
+++ b/site/_includes/tour-map.html
@@ -1,0 +1,134 @@
+<!--
+  Tour map render — uses Leaflet 1.9 (CDN) on OpenStreetMap tiles.
+  Data: site/_data/tour_venues.yml
+  Embedded on: site/tour.md
+-->
+
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin=""/>
+
+<figure class="tour-map-figure">
+  <div id="tour-map" class="tour-map" aria-label="World map of verified Family of Man tour venues"></div>
+  <figcaption>
+    <strong>Verified tour venues, 1955–1994.</strong>
+    Three waves, colour-coded:
+    <span class="legend-swatch" style="background:#1e3a8a"></span> 1955–56 US domestic (6) ·
+    <span class="legend-swatch" style="background:#b91c1c"></span> 1955–c.1965 international (5) ·
+    <span class="legend-swatch" style="background:#15803d"></span> 1992–94 second wave (3).
+    Hover or tap a marker for venue, dates, and source. Country-level-only mentions (India, Mexico, Germany, Australia, etc.) are not plotted because no in-repo source attests a specific city or dates for them. See <a href="{{ '/tour/' | relative_url }}#verifiable-venues-abroad">Verifiable venues abroad</a> for the underlying data and provenance.
+  </figcaption>
+</figure>
+
+<style>
+  .tour-map-figure {
+    margin: 1.5rem 0 2rem;
+  }
+  .tour-map {
+    height: 480px;
+    width: 100%;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+  }
+  .tour-map-figure figcaption {
+    margin-top: 0.5rem;
+    font-size: 0.9rem;
+    color: #4b5563;
+    line-height: 1.5;
+  }
+  .legend-swatch {
+    display: inline-block;
+    width: 0.7em;
+    height: 0.7em;
+    border-radius: 50%;
+    margin: 0 0.15em 0 0.4em;
+    vertical-align: middle;
+  }
+  .leaflet-popup-content strong {
+    display: block;
+    margin-bottom: 0.2em;
+  }
+  .leaflet-popup-content .popup-wave {
+    font-size: 0.8em;
+    color: #6b7280;
+    margin-top: 0.3em;
+  }
+</style>
+
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+        integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+        crossorigin=""></script>
+
+<script>
+  (function() {
+    var venues = [
+      {%- for v in site.data.tour_venues.venues %}
+      {
+        city: {{ v.city | jsonify }},
+        country: {{ v.country | jsonify }},
+        lat: {{ v.lat }},
+        lon: {{ v.lon }},
+        venue: {{ v.venue | jsonify }},
+        dates: {{ v.dates | jsonify }},
+        wave: {{ v.wave | jsonify }},
+        source: {{ v.source | jsonify }},
+        note: {{ v.note | default: '' | jsonify }}
+      }{% unless forloop.last %},{% endunless %}
+      {%- endfor %}
+    ];
+
+    var waveColors = {
+      'us-domestic': '#1e3a8a',
+      'international-1955-65': '#b91c1c',
+      'second-wave-1992-94': '#15803d'
+    };
+
+    var waveLabels = {
+      'us-domestic': '1955–56 US domestic tour',
+      'international-1955-65': '1955–c.1965 international (USIA)',
+      'second-wave-1992-94': '1992–94 second wave (restored prints)'
+    };
+
+    var map = L.map('tour-map', {
+      center: [25, 0],
+      zoom: 2,
+      worldCopyJump: true,
+      scrollWheelZoom: false
+    });
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      maxZoom: 18
+    }).addTo(map);
+
+    venues.forEach(function(v) {
+      var marker = L.circleMarker([v.lat, v.lon], {
+        radius: 7,
+        fillColor: waveColors[v.wave] || '#6b7280',
+        color: '#ffffff',
+        weight: 2,
+        opacity: 1,
+        fillOpacity: 0.9
+      });
+
+      var html = '<strong>' + escape(v.city) + (v.country ? ', ' + escape(v.country) : '') + '</strong>';
+      if (v.venue) html += escape(v.venue) + '<br>';
+      html += escape(v.dates);
+      if (v.note) html += '<br><em>' + escape(v.note) + '</em>';
+      html += '<div class="popup-wave">' + escape(waveLabels[v.wave] || v.wave) + ' &middot; ' + escape(v.source) + '</div>';
+
+      marker.bindPopup(html, { maxWidth: 280 });
+      marker.addTo(map);
+    });
+
+    function escape(s) {
+      if (!s) return '';
+      return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+    }
+  })();
+</script>

--- a/site/_includes/tour-map.html
+++ b/site/_includes/tour-map.html
@@ -16,7 +16,7 @@
     <span class="legend-swatch" style="background:#1e3a8a"></span> 1955–56 US domestic (6) ·
     <span class="legend-swatch" style="background:#b91c1c"></span> 1955–c.1965 international (5) ·
     <span class="legend-swatch" style="background:#15803d"></span> 1992–94 second wave (3).
-    Hover or tap a marker for venue, dates, and source. Country-level-only mentions (India, Mexico, Germany, Australia, etc.) are not plotted because no in-repo source attests a specific city or dates for them. See <a href="{{ '/tour/' | relative_url }}#verifiable-venues-abroad">Verifiable venues abroad</a> for the underlying data and provenance.
+    Hover or tap a marker for venue, dates, and source. Country-level-only mentions in the CNA portal's open-ended sample list (India, Mexico, Germany, Australia, the historically-anachronistic "Zimbabwe" for what was Southern Rhodesia 1955–65, and the non-plotted French / Russian venues beyond Toulouse and Moscow) are not shown because no in-repo source attests a specific city or dates for them. See <a href="{{ '/tour/' | relative_url }}#verifiable-venues-abroad">Verifiable venues abroad</a> for the underlying data and provenance.
   </figcaption>
 </figure>
 

--- a/site/tour.md
+++ b/site/tour.md
@@ -30,6 +30,8 @@ edit_dir: site
 
 After the New York show closed on 8 May 1955, *The Family of Man* did not stop — it multiplied. Over the next decade, multiple physically distinct copies circulated under the auspices of the **United States Information Agency (USIA)**, reaching audiences across continents and becoming one of the most-cited instruments of mid-century U.S. cultural diplomacy. This page traces what is *verifiable* about that circulation from sources in this wiki, and is unusually explicit about what is *not*.
 
+{% include tour-map.html %}
+
 ## How the tour actually worked
 
 The tour was not a single physical installation moving from city to city. From the outset, MoMA produced **multiple circulating editions** — physically distinct copies, partially overlapping with the 1955 New York hang but re-fabricated for travel.[^1] The CNA Luxembourg education portal characterises the operational model: between 1955 and 1964, *"the exhibition became itinerant and toured the world ... in the form of ten copies with minor changes sent to nearly 160 towns. Each of the copies was weighing one tonne and a half, was packed in twenty-three crates and required more than six days to be mounted/installed."*[^2]


### PR DESCRIPTION
Closes #59.

## Summary

Geographic visualisation of the 14 verified Family of Man tour venues, embedded on \`/tour/\` after the lead paragraph.

**Three files:**
- \`site/_data/tour_venues.yml\` — 14 venues with city, country, coords, dates, tour-wave, source-id
- \`site/_includes/tour-map.html\` — Leaflet 1.9 (CDN) on OpenStreetMap tiles, three colour-coded waves
- \`site/tour.md\` — \`{% include tour-map.html %}\` after lead paragraph

## Three colour-coded waves

- **Blue (6 venues)** — 1955-56 US domestic tour, all attested in \`src-moma-1955-press-release-book\` p. 2: Minneapolis, Dallas, Cleveland, Philadelphia, Baltimore, Pittsburgh
- **Red (5 venues)** — 1955-c.1965 international: Washington DC (Corcoran, src-moma-1955-press-release-book), Guatemala City, Tokyo 1956, Johannesburg, Moscow (year-only) — last 4 from \`src-cna-education\`
- **Green (3 venues)** — 1992-94 second wave (restored prints): Toulouse, Tokyo, Hiroshima — all from \`src-unesco-mow-2003\`

## Provenance discipline

Every plotted venue is attested in an in-repo source-entry's Key excerpts. Country-level-only mentions on the CNA portal (India, France-non-Toulouse, Mexico, Germany, Australia, anachronistic 'Zimbabwe') are NOT plotted because no specific city or dates are attested. Coordinates are city centroids from general geographic knowledge with an explicit non-source-corroboration disclaimer in the data file's frontmatter.

## Test plan

- [ ] Schema judge: YAML parses, scripts pass (verified locally — 14 venues / 3 waves / 6+5+3)
- [ ] Credibility judge: every venue cites a real source-id; no rejected source types
- [ ] Grounding judge: spot-check each venue's source attribution against the cited source-entry's Key excerpts
- [ ] Bias judge: visualization framing is even-handed; the legend shows three waves without privileging one; the Sokolniki / Kitchen Debate identification is correctly NOT plotted as fact

## Local rendering note

Cannot test live render in this session (no Jekyll Docker setup). The Leaflet CDN URLs and SRI hashes use the standard Leaflet 1.9.4 release. If the build fails or markers don't render correctly, the popup-escape function and the Liquid \`jsonify\` filter usage are the most likely culprits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)