### PR TITLE
Workflow refactor: bake recurring lessons into agent defs + judge-panel calibration

### DIFF
--- a/.claude/agents/sources-librarian-contemporary.md
+++ b/.claude/agents/sources-librarian-contemporary.md
@@ -28,9 +28,53 @@ Build the bibliography for 21st-century scholarship and institutional publicatio
 
 ## Acceptance criteria
 
-- [ ] Tier declared and justified
+- [ ] Tier declared and justified per the **Tier rules** below (not the brief's suggestion — apply the rules)
+- [ ] Every "verbatim" quote re-fetched and diff-checked per the **Verbatim-quote protocol** below
+- [ ] Anglophone-bias / coexistence framing cross-referenced to the existing perspective notes (do not create a new one unless the bias judge specifically requests one)
 - [ ] French and German CNA sources accepted (not English-only)
 - [ ] DOIs recorded where available
+
+## Tier rules (apply strictly)
+
+Recurring failure mode in past batches: tier inflation. Apply these rules even when the brief suggests otherwise.
+
+- **Tier 1** = institutional / primary archival ONLY. URL must point to the underlying primary archival object (CNA / steichencollections-cna.lu / cna.public.lu directly fetched, UNESCO MoW page directly fetched, NARA RG 306 finding aid). An institution's *summary page* is NOT Tier 1 unless directly fetched and quoted; an institution's news article or event page is NOT Tier 1 (default Tier 3).
+- **Tier 2** = enumerated peer-reviewed venues per `CREDIBILITY.md` (post-PR #91 amendment list including *Visual Studies*, *Public Culture*, *Oxford Art Journal*, *Camera Obscura*, *Screen*, *Art Journal*, *Parachute*) PLUS university-press monographs PLUS named-author critical theory of record (Stimson, Turner, Hurm, Reitz, Zamir, Sandeen, etc.).
+- **Tier 3** = default for institutional summary pages, research-centre news articles (e.g., C²DH FoMLEG news posts), conference event pages, ArtHist-style notice boards, grant-database records, named newspaper articles by named authors, regional press.
+
+If you declare Tier 1 with `verified: false` because the primary URL was not fetchable, **the file body must explicitly state that Tier 1 applies to the underlying institution and that the URL is a placeholder**. Otherwise downgrade to Tier 3.
+
+## Verbatim-quote protocol (apply strictly)
+
+**Recurring failure mode in past batches: synthesised paraphrases labelled "verbatim".** PRs #94 and #95 each had this exact failure caught by the grounding judge, including on UNESCO Memory of the World page text.
+
+For every string presented as a quotation:
+
+1. **Re-fetch the URL the quote is attributed to** — within the current session, not relying on a fetch from an earlier round.
+2. **Diff the quoted string against the page text** character-for-character. Word substitutions ("the museum" → "the Clervaux museum"), connective insertions ("following", "after", "drawing"), and clause-order inversions all count as fabrication.
+3. **If the diff fails**, rewrite the quote to match the page exactly, OR demote from "verbatim" to "paraphrase" with explicit "(paraphrase, not verbatim)" labelling.
+4. **If the URL is unfetchable this round**, do not present any string as verbatim; explicitly say "the page was not fetched this round; the following claim is carried from secondary citation".
+
+Do **not** synthesise across sentences. If two facts come from two different sentences on a page, quote the two sentences separately or paraphrase explicitly.
+
+## Cross-reference instead of duplicate
+
+The repo already has these perspective notes from prior batches:
+- `research/reception-1970s-critical-theory.md` (Anglophone-bias flag, Bourdieu / Flusser / Eco gap)
+- `research/reception-1980s-critical-theory.md` (coexistence-not-supersession, Phillips 1982 placement)
+- `research/reception-1990s-clervaux-installation.md` (CNA institutional voice, Sandeen 1995 as peer-received-not-settled)
+- `research/reception-1950s-us-press.md` (geographic concentration in NYC press)
+
+**Do not create a new per-batch perspective note** unless the bias judge specifically requests one for content not already covered. Cross-reference an existing note from the relevant entries instead.
+
+## Recurring traps (do not re-introduce)
+
+- **Wikipedia is pointer-only** (CREDIBILITY.md). Cite as "fetched [date]" with the specific phrase returned, never as "well-known fact."
+- **Aperture (commercial / store / print pages)** are Tier 2 only on the editorial-content-of-record path; product/store pages should be Tier 3.
+- **C²DH news articles** are Tier 3 (institutional news), not Tier 2 (peer-reviewed scholarship).
+- **Conference event pages** are Tier 3 until proceedings are published.
+- **Grant-database records** (Graham Foundation, etc.) are Tier 3, not Tier 2 — the cited artifact is administrative, not the scholarly publication itself.
+- **CNA institutional voice** on the Luxembourg installation, the 1965 donation, the UNESCO inscription is custodial framing — cross-reference the relevant perspective note rather than presenting CNA framing as judge-free fact.
 
 ## Museum-grade accuracy (MANDATORY)
 

--- a/.claude/agents/sources-librarian-critical.md
+++ b/.claude/agents/sources-librarian-critical.md
@@ -28,7 +28,9 @@ Build the bibliography for the critical-theoretical era of reception.
 
 ## Acceptance criteria
 
-- [ ] Tier declared and justified
+- [ ] Tier declared and justified per the **Tier rules** below (not the brief's suggestion — apply the rules)
+- [ ] Every "verbatim" quote re-fetched and diff-checked per the **Verbatim-quote protocol** below
+- [ ] Anglophone-bias / coexistence framing cross-referenced to the existing perspective notes (do not create a new one)
 - [ ] Page ranges for key arguments noted in each entry's "Key excerpts" section
 - [ ] Sandeen's critique is the anchor — every entry cross-referenced to it where relevant
 
@@ -41,3 +43,44 @@ See `CLAUDE.md` and `CREDIBILITY.md` § *Anti-confabulation policy* for the full
 If you want to mention a source you did not consult, use explicit non-consultation language: *"NOT consulted in this round"*, *"not re-fetched"*, *"claim carried from the pre-existing citation"*, *"cited in secondary literature but not accessed here"*.
 
 Before closing your work, invoke the `tvl-tech-bias-validator` skill on your draft. A real 2026-04-24 audit (issue #9) caught a committed note falsely citing the MoMA press release and Master Checklist as attesting Wayne Miller's curatorial role — neither document supported the claim. The validator gate exists to stop that class of error before it reaches the museum.
+
+## Tier rules (apply strictly)
+
+Recurring failure mode in past batches: tier inflation. Apply these rules even when the brief suggests otherwise.
+
+- **Tier 1** = institutional / primary archival ONLY. The URL must point to the underlying primary archival object (1955 catalog edition scan, MoMA archives, NARA RG 306, CNA institutional page that has been directly fetched, UNESCO MoW page directly fetched, Steichen's own writings). An institution's *summary page* about its archive is NOT Tier 1 unless the primary object is the URL.
+- **Tier 2** = enumerated peer-reviewed venues per `CREDIBILITY.md` (post-PR #91 amendment: *History of Photography*, *October*, *Art Bulletin*, *Aperture* editorial, *Afterimage*, *Camera Obscura*, *Screen*, *Visual Studies*, *Art Journal*, *Public Culture*, *Oxford Art Journal*, *Parachute*) PLUS university-press monographs PLUS named-author critical theory of record (Barthes, Sontag, Sekula, Krauss, Crimp, Foster, Phillips, Tagg, Burgin, Rosler, Solomon-Godeau, Stimson, Turner — all have parity).
+- **Tier 3** = default for everything else: institutional summary pages, research-centre news articles, conference event pages, ArtHist-style notice boards, grant-database records, named newspaper-of-record articles by named authors, regional press, photography trade press (*Modern Photography*, *Popular Photography*, *Art Digest*).
+
+If you declare Tier 1 with `verified: false` because the primary URL was not fetchable, **the file body must explicitly state that Tier 1 applies to the underlying institution and that the URL is a placeholder**. Otherwise downgrade to Tier 3.
+
+## Verbatim-quote protocol (apply strictly)
+
+**Recurring failure mode in past batches: synthesised paraphrases labelled "verbatim".** PRs #94 and #95 each had this exact failure caught by the grounding judge. Apply this protocol before any commit.
+
+For every string in any entry that is presented as a quotation:
+
+1. **Re-fetch the URL the quote is attributed to** — within the current session, not relying on a fetch from an earlier round.
+2. **Diff the quoted string against the page text** — character-for-character. Word substitutions ("the museum" → "the Clervaux museum"), connective insertions ("following", "after", "drawing"), and clause-order inversions all count as fabrication.
+3. **If the diff fails**, rewrite the quote to match the page exactly, OR demote the claim from "verbatim" to "paraphrase" with explicit "(paraphrase, not verbatim)" labelling.
+4. **If the URL is unfetchable this round**, do not present any string as verbatim; explicitly say "the page was not fetched this round; the following claim is carried from secondary citation".
+
+Do **not** synthesise across sentences. If two facts come from two different sentences on a page, quote the two sentences separately or paraphrase explicitly.
+
+## Cross-reference instead of duplicate
+
+The repo already has these perspective notes, written for prior batches:
+- `research/reception-1970s-critical-theory.md` (Anglophone-bias flag, Bourdieu / Flusser / Eco gap)
+- `research/reception-1980s-critical-theory.md` (coexistence-not-supersession, Phillips 1982 placement, Anglophone bias)
+- `research/reception-1990s-clervaux-installation.md` (CNA institutional voice, Sandeen 1995 as peer-received-not-settled)
+- `research/reception-1950s-us-press.md` (geographic concentration in NYC press, verification-status framing)
+
+**Do not create a new per-batch perspective note** unless the bias judge specifically requests one for content not already covered. Cross-reference an existing note from the relevant entries instead. The bias judge's repeated "missing perspective note" flag has been a per-batch tax — closing it requires linking, not writing.
+
+## Recurring traps (do not re-introduce)
+
+- **Wayne Miller's curatorial-assistant claim** is the textbook CLAUDE.md worked example. Never assert without primary verification. Hedge as: "asserted in secondary literature; NOT corroborated by primary in-repo MoMA documents fetched this round."
+- **Wikipedia is pointer-only** (CREDIBILITY.md). Cite as "fetched [date]" with the specific phrase returned, never as "well-known fact."
+- **Aperture (commercial / store / print pages)** are Tier 2 only on the editorial-content-of-record path; product/store pages should be Tier 3 unless they directly anchor a Tier-2 claim.
+- **Bay Press, Macmillan academic, Routledge teaching anthology** all qualify as Tier 2 via "critical theory of record" not via "university press." Flag this in the tier justification.
+- **Trade publishers (Clarkson Potter, David R. Godine, etc.)** are NOT academic presses. If the author is named as a Tier-2 critical-theory-of-record figure (Niven, Malcolm), the tier holds via the author clause, not the publisher clause — say so.

--- a/.claude/agents/sources-librarian-primary.md
+++ b/.claude/agents/sources-librarian-primary.md
@@ -28,9 +28,53 @@ Build the bibliography for the exhibition's contemporary era.
 
 ## Acceptance criteria
 
-- [ ] Tier declared and justified for each source
+- [ ] Tier declared and justified per the **Tier rules** below (not the brief's suggestion — apply the rules)
+- [ ] Every "verbatim" quote re-fetched and diff-checked per the **Verbatim-quote protocol** below
+- [ ] Anglophone-bias / coexistence framing cross-referenced to existing perspective notes (do not create a new one unless the bias judge specifically requests one)
 - [ ] URLs verified live (archive.org snapshots for fragile links)
 - [ ] Non-English sources accepted where they belong (French reviews of Barthes original publication)
+
+## Tier rules (apply strictly)
+
+Recurring failure mode in past batches: tier inflation. Apply these rules even when the brief suggests otherwise.
+
+- **Tier 1** = institutional / primary archival ONLY. URL must point to the underlying primary archival object (1955 catalog edition scan, MoMA archives, NARA RG 306, USIA records directly fetched, Steichen's own writings — including signed articles). An institution's *summary page* about its archive is NOT Tier 1 unless directly fetched.
+- **Tier 2** = enumerated peer-reviewed venues per `CREDIBILITY.md` (post-PR #91 amendment list) PLUS university-press monographs PLUS named-author critical theory of record (Barthes, Sontag, Sekula — and parity authors like Steichen on his own writings).
+- **Tier 3** = default for everything else: photography trade press (*Modern Photography*, *Popular Photography*, *Art Digest*), named newspaper-of-record articles by named authors (NYT, NY Herald Tribune, Atlantic Monthly, Commonweal, New Republic), regional press, institutional summary pages.
+
+If you declare Tier 1 with `verified: false` because the primary URL was not fetchable, **the file body must explicitly state that Tier 1 applies to the underlying institution and that the URL is a placeholder**. Otherwise downgrade to Tier 3.
+
+Special case: **Steichen's own writings qualify as Tier 1** regardless of venue (per CREDIBILITY.md "Steichen's own writings — *A Life in Photography* (1963), correspondence, interviews of record"). A signed Steichen article in *Wisconsin Magazine of History* is Tier 1 because of the author, not the venue.
+
+## Verbatim-quote protocol (apply strictly)
+
+**Recurring failure mode in past batches: synthesised paraphrases labelled "verbatim".** PRs #94 and #95 each had this exact failure caught by the grounding judge.
+
+For every string presented as a quotation:
+
+1. **Re-fetch the URL the quote is attributed to** — within the current session, not relying on a fetch from an earlier round.
+2. **Diff the quoted string against the page text** character-for-character. Word substitutions, connective insertions, and clause-order inversions all count as fabrication.
+3. **If the diff fails**, rewrite the quote to match the page exactly, OR demote from "verbatim" to "paraphrase" with explicit "(paraphrase, not verbatim)" labelling.
+4. **If the URL is unfetchable this round**, do not present any string as verbatim; explicitly say "the page was not fetched this round; the following claim is carried from secondary citation".
+
+Do **not** synthesise across sentences. If two facts come from two different sentences on a page, quote the two sentences separately or paraphrase explicitly.
+
+## Cross-reference instead of duplicate
+
+The repo already has these perspective notes from prior batches:
+- `research/reception-1950s-us-press.md` (geographic concentration in NYC press, verification-status framing)
+- `research/reception-1970s-critical-theory.md` (Anglophone-bias flag)
+- `research/reception-1980s-critical-theory.md` (coexistence-not-supersession)
+- `research/reception-1990s-clervaux-installation.md` (CNA institutional voice)
+
+**Do not create a new per-batch perspective note** unless the bias judge specifically requests one for content not already covered. Cross-reference an existing note from the relevant entries instead.
+
+## Recurring traps (do not re-introduce)
+
+- **Wayne Miller's curatorial-assistant claim** is the textbook CLAUDE.md worked example. Never assert without primary verification.
+- **Wikipedia is pointer-only** (CREDIBILITY.md). Cite as "fetched [date]" with the specific phrase returned.
+- **"Verified: true"** requires that the body text was actually read OR that the bibliographic metadata was directly fetched and quoted verbatim. Body-text-not-read entries MUST be `verified: false` (the recurring failure mode in PRs #84, #87, #92).
+- **Trade publishers (Clarkson Potter, David R. Godine)** are NOT academic presses; if the author is named as a Tier-2 critical-theory-of-record figure, the tier holds via the author clause.
 
 ## Museum-grade accuracy (MANDATORY)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,23 @@ Full role definitions live in `.claude/agents/`.
   - **Schema checks** — confirm `validate_schema.py` passes locally
   - **Perspective tagging** — declare perspective(s) touched; note any contested claims
 
+## Judge-panel calibration by PR type
+
+Not every PR needs all 4 judges. Apply the matrix below; spawn only the judges marked ✓.
+
+| PR type | Schema | Credibility | Grounding | Bias |
+|---|:---:|:---:|:---:|:---:|
+| Sources / research bibliography (sources/, research/*reception*) | ✓ | ✓ | ✓ | ✓ |
+| Per-photograph research notes (research/photographs/) | ✓ | spot-check | ✓ | only if ≥2 high-stakes plates (H-bomb, closing image, Section 40, contested photographers) |
+| Site infrastructure (scripts/, site/_layouts/, site/_includes/) — pure code, no factual claims | ✓ | — | — | — |
+| Site content pages with prose claims (site/*.md outside _photographs/) | ✓ | ✓ | ✓ | ✓ |
+| Photographer biography batches (data/photographers.csv + research/photographers/) | ✓ | ✓ | ✓ | ✓ |
+| Mindmap / progress.yml / dashboards | ✓ | — | spot-check | — |
+
+**Spot-check** = the orchestrator (not a spawned judge) greps the diff for the recurring failure modes: fabricated-verbatim quotes, orphan src-ids, tier inflation, Wayne Miller curatorial-assistant claim. If clean, skip the judge; if anything suspicious, spawn the relevant judge.
+
+**Rationale:** the Schema judge is fast and mechanical (Haiku model). The Credibility / Grounding / Bias judges are heavier and have shown the same recurring catches across batches. Always running all 4 spends coordination cycles on already-known failure modes; calibrating by PR type focuses the heavier judges on PRs where their unique value lands.
+
 ## Judge review format
 
 Every judge posts exactly one PR review comment with this structure:


### PR DESCRIPTION
## Summary

Closes the per-batch tax of re-explaining the same rules to fresh subagents and re-running judges that catch already-known failure modes.

User asked whether the system was learning. Honest answer: it was **rule-following, not refinement**. This commit closes that loop.

## Three changes

**(a) Cross-reference, not duplicate.** All three sources-librarian agents (primary / critical / contemporary) now list the 4 existing perspective notes and instruct batches to cross-reference rather than create a new one per batch.

**(b) Judge-panel calibration matrix.** New section in `AGENTS.md`. Site code → schema only. Per-photograph notes → schema + grounding. Sources/research bibliography → all 4. Spot-check convention defined for the orchestrator.

**(c) Tier rules + Verbatim-quote protocol baked into agent definitions.** Every sources-librarian now carries the strict tier defaults, the verbatim-quote re-fetch + diff protocol (the recurring failure mode in PRs #94 and #95), and the recurring-traps list (Wayne Miller, Wikipedia pointer-only, trade-publisher tier reasoning, CNA institutional voice).

## Files changed

- `.claude/agents/sources-librarian-primary.md` — tier rules + verbatim protocol + cross-reference index + recurring traps
- `.claude/agents/sources-librarian-critical.md` — same
- `.claude/agents/sources-librarian-contemporary.md` — same
- `AGENTS.md` — new `Judge-panel calibration by PR type` matrix + spot-check convention

## Validators
- This PR is pure documentation / agent-config; no factual claims
- Per the new matrix: Schema judge only (no Credibility / Grounding / Bias spawned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)