### PR TITLE
Eval set v0.1 seed: 50 held-out questions

### DIFF
--- a/research/reception-2000s-stimson-era.md
+++ b/research/reception-2000s-stimson-era.md
@@ -1,0 +1,409 @@
+---
+title: "2000s reception: Stimson era, the fiftieth-anniversary cluster, and the UNESCO inscription effect"
+status: draft
+last_updated: 2026-05-07
+perspective: [critical, historical, institutional]
+contested: true
+sources:
+  - src-stimson-2006
+  - src-back-schmidt-linsenhoff-2004
+  - src-history-of-photography-2005-fom-special-issue
+  - src-vettel-becker-caa-reviews-stimson-kaplan
+  - src-ribalta-2008-public-photographic-spaces
+  - src-azoulay-2008-civil-contract
+  - src-azoulay-2001-deaths-showcase
+  - src-batchen-2001-each-wild-idea
+  - src-lugon-2001-style-documentaire
+  - src-elkins-2007-photography-theory
+  - src-fom-catalog-50th-anniversary-2004
+  - src-brandow-ewing-2008-steichen-lives
+  - src-grey-room-founded-2000
+  - src-unesco-mow-2003
+  - src-unesco-mow-nomination-en-2002
+  - src-unesco-mow-nomination-fr-2002
+fresh_fetches_this_round:
+  - "https://archive.org/details/pivotofworldphot00stim (2026-05-07) — IA item page; access-restricted, body text NOT borrowed; bibliographic metadata only"
+  - "https://archive.org/metadata/pivotofworldphot00stim (2026-05-07) — IA metadata API; subjects, ISBN, page count confirmed"
+  - "https://www.steichencollections-cna.lu/eng/collections/1_the-family-of-man (2026-05-07) — CNA institutional voice on restoration timeline and 2003 UNESCO inscription"
+  - "https://www.thefamilyofman.education/en/historical-context/the-family-of-man-a-greater-resonance-more-than-ever-before (2026-05-07) — CNA education portal; current institutional framing"
+  - "https://www.uni.lu/c2dh-en/news/the-family-of-man-lasting-legacy/ (2026-05-07) — University of Luxembourg C²DH 2024 research-project announcement; provides 2026 horizon framing only"
+  - "Google search snippets to https://www.tandfonline.com/doi/abs/10.1080/03087298.2005.10442813 and …/10442814 (2026-05-07) — bibliographic metadata for the History of Photography 2005 special issue"
+  - "Google search snippet to https://caareviews.org/reviews/1074 (2026-05-07) — Vettel-Becker review identification"
+  - "WebFetch to caareviews.org/reviews/1074, mitpress.mit.edu/9780262693332/, philpapers.org/rec/STITPO-11, books.google.com/…, fredturner.stanford.edu/…/turner-family-of-man-pc-24.1.pdf, apjjf.org/john-obrian/2816/article, alisetifentale.net/…/Tifentale_Alise_the_Family_of_Man.pdf, theguardian.com/artanddesign/2010/jun/06/… — ALL denied (403 / permission-denied) this round; body text NOT obtained from any of them"
+  - "https://en.wikipedia.org/wiki/The_Family_of_Man (2026-05-07) — only the 2003 UNESCO sentence and 'Fred Turner... defender, detailed analysis' fragment confirmed via direct fetch"
+---
+
+# 2000s reception: Stimson era, the fiftieth-anniversary cluster, and the UNESCO inscription effect
+
+This essay accompanies the 2000s bench of source entries
+(`sources/2000s/`) and continues the decade-by-decade reception thread
+established in `research/reception-1950s-us-press.md`,
+`research/reception-1970s-critical-theory.md`,
+`research/reception-1980s-critical-theory.md`, and
+`research/reception-1990s-clervaux-installation.md`. It is to be read
+alongside `research/unesco.md` (institutional account of the 2003
+Memory of the World inscription, fetched 2026-04-29) and
+`research/clervaux.md` (custodial history at the CNA).
+
+The 2000s are the decade in which two things happen simultaneously to
+*The Family of Man*: it is canonised by UNESCO as documentary heritage
+of "world significance and outstanding universal value" (2003), and it
+is re-read by Anglophone and European photography-theory scholarship
+as a more interesting object than the *October*-axis 1980s critique
+had treated it as. The two movements overlap chronologically but do
+not amount to the same gesture, and a reader of this period's
+secondary literature has to keep them separate.
+
+## 1. The pre-2000 horizon, briefly
+
+The reception thread carries the following positions into the 2000s:
+
+- Roland Barthes 1957 — the foundational critique that the show codes
+  history as nature [src-barthes-1957].
+- Susan Sontag 1977 — the popular extension of the Barthesian reading
+  into Anglophone book-publishing, although her direct engagement with
+  *Family of Man* is brief [src-sontag-1977; not re-read this round].
+- Allan Sekula 1981 / 1986 — the *Art Journal* / Bay Press
+  consolidation of the political critique, repositioning the show as
+  ideologically continuous with US Cold War cultural diplomacy
+  [src-sekula-1981, src-sekula-1986; not re-read this round].
+- Christopher Phillips 1982 — the *October* "Judgment Seat" reading
+  of MoMA's photography apparatus [src-phillips-1982-judgment-seat;
+  not re-read this round].
+- Eric Sandeen 1995 — the historical-contextual book-length study,
+  reviewed in *AHR* and *Journal of American Studies*
+  [src-sandeen-1995; characterized at the level of overall argument
+  in `research/reception-1990s-clervaux-installation.md`].
+
+By 2000 the academic field has settled, in broad outline, into two
+camps: a critical consensus (Barthes / Sekula / Phillips axis) reading
+the exhibition as ideologically problematic, and a
+historical-contextual reading (Sandeen) treating it as a worked
+artefact in need of careful reconstruction. The 2000s do not overturn
+this; they re-read it.
+
+## 2. The fiftieth-anniversary cluster, 2004–2006
+
+Three Anglophone- or European-scholarly events define the 2000s
+re-reading:
+
+- **2004.** Jean Back (CNA Luxembourg) and Viktoria Schmidt-Linsenhoff
+  (University of Trier), eds., *The Family of Man 1955–2001:
+  Humanismus und Postmoderne / Humanism and Postmodernism: a
+  reappraisal of the photo exhibition by Edward Steichen* (Jonas
+  Verlag, Marburg). Bilingual German/English. The volume's full title
+  was confirmed against the Internet Archive catalog record on
+  2026-04-30 [src-back-schmidt-linsenhoff-2004]. The body text was
+  NOT accessed in any session of this project so far; the access-
+  restricted IA scan blocked content review. The volume's
+  programmatic title — "Humanism and Postmodernism: a reappraisal"
+  — is itself the strongest indication of the 2000s framing: a
+  reappraisal, not a verdict.
+- **2005.** *History of Photography* (Routledge / Taylor & Francis),
+  vol. 29, no. 4 (Winter 2005): a special issue marking the fiftieth
+  anniversary of the 1955 MoMA opening. Katherine Hoffman's
+  introduction (pp. 317–319) opens by stating that the exhibition
+  "merits renewed exploration as it surpasses its fiftieth
+  anniversary" [src-history-of-photography-2005-fom-special-issue;
+  search-snippet attribution to the tandfonline DOI page, full text
+  not fetched]. The issue's table of contents is partially confirmed
+  through a second Taylor & Francis DOI lookup (DOI
+  10.1080/03087298.2005.10442814 — "Sowing the seeds / setting the
+  stage: Steichen, Stieglitz and *The Family of Man*"), but the full
+  list of articles in the issue has not been fetched.
+- **2006.** Blake Stimson, *The Pivot of the World: Photography and
+  Its Nation* (MIT Press) [src-stimson-2006]. Stimson treats *The
+  Family of Man* as one of three central post-war photographic
+  projects, alongside Robert Frank's *The Americans* and Bernd and
+  Hilla Becher's typological photographs of industrial structures.
+
+A fourth landmark — Jorge Ribalta (ed.), *Public Photographic Spaces:
+Exhibitions of Propaganda, from* Pressa *to the* Family of Man,
+*1928–55* (MACBA, Barcelona, 2008) [src-ribalta-2008-public-photographic-spaces]
+— sits at the end of the cluster and reframes the
+exhibition genealogically rather than psychologically: as the closing
+term in a longer twentieth-century sequence of politically
+instrumentalised mass-photographic exhibitions running from the 1928
+*Pressa* exhibition forward.
+
+The four titles together constitute the densest cluster of
+peer-reviewed and academic-press engagement with *The Family of Man*
+since the 1980s *October*-axis critique. None of them returns to a
+verdict-style reading; all four operate in the register of "what was
+this object actually doing, and what does it mean to look at it
+again."
+
+## 3. Stimson 2006 — what is and is not verifiable in this round
+
+This is the section where the museum-grade-accuracy rule
+(`CLAUDE.md`) bites hardest. Blake Stimson's *The Pivot of the World*
+is repeatedly cited in secondary literature about *The Family of
+Man*; loose paraphrases of his argument circulate widely. The book
+itself is access-restricted on Internet Archive (CDL borrow not
+completed in any session of this project); the MIT Press product
+page returned 403 on 2026-05-07; CAA Reviews, PhilPapers, Google
+Books, ProQuest, and a Stanford-hosted Turner PDF were all
+permission-denied this round.
+
+What is verifiable from successful fetches: the book exists, was
+published by MIT Press in 2006, has 238 pages, ISBN 9780262693332,
+Library of Congress subjects "Photography — Social aspects" and
+"Photographic criticism" (IA metadata API,
+`pivotofworldphot00stim`, 2026-04-30 and re-confirmed 2026-05-07)
+[src-stimson-2006]. Reviewers consistently characterise the book as a
+study of three 1950s photographic projects: *The Family of Man*,
+Robert Frank's *The Americans*, and the Bechers' industrial typology
+[src-vettel-becker-caa-reviews-stimson-kaplan]. This framing is NOT
+confirmed against Stimson's own text in this round.
+
+What is NOT verifiable: Stimson's specific page-level argument about
+*The Family of Man*; page numbers in his chapter on the exhibition;
+his verbatim phrasing about the "pivot" — the title-term widely
+paraphrased in secondary literature as the moment a viewer inserts
+themselves between two photographs and identifies into a collective;
+his verdict on Barthes, Sekula, or Phillips. The Google search
+summary attributes the "pivot" characterisation to the caa.reviews
+Vettel-Becker review, but the review body was not fetched and the
+formulation has not been confirmed against Stimson's own text.
+
+The honest summary: **Stimson 2006 is the canonical 2000s scholarly
+engagement with *The Family of Man* and must be cited as such, but
+the specific content of his argument is carried in this repository at
+the level of "secondary characterisation" and not at the level of
+verbatim quotation.** The `/reception/` site page mentions Stimson by
+bibliographic metadata only and defers content claims pending a
+direct read. This essay does the same. A future pass should complete
+a CDL borrow and quote Stimson's *Family of Man* chapter directly,
+with page numbers.
+
+## 4. The European-scholarly axis: Back / Schmidt-Linsenhoff, Lugon, Ribalta
+
+The 2000s see the strongest European-language scholarship since
+Barthes himself. **Back / Schmidt-Linsenhoff 2004**
+[src-back-schmidt-linsenhoff-2004] is the only book-length European
+scholarly reappraisal of *The Family of Man* in the decade. Its
+bilingual German/English form, its CNA-Luxembourg connection (Jean
+Back was a CNA-affiliated co-editor; his exact CNA role and title
+are NOT confirmed from any source fetched in this round), and its
+programmatic "humanism and postmodernism" framing make it the natural
+pair to Stimson 2006. Body text unread. The political-geographic
+significance is that the Luxembourg holding institution was
+co-producing scholarship about its own collection during the same
+period it was preparing the 2002–2003 UNESCO nomination dossier.
+
+**Olivier Lugon 2001**, *Le Style documentaire: d'August Sander à
+Walker Evans, 1920–1945* (Macula, Paris)
+[src-lugon-2001-style-documentaire] is not directly about *The Family
+of Man* but is the decade's most sustained French-language treatment
+of the documentary tradition out of which the exhibition was built.
+Body text NOT read; bibliographic metadata not yet confirmed against
+a library catalog.
+
+**Ribalta 2008** (MACBA) [src-ribalta-2008-public-photographic-spaces]
+reframes the exhibition genealogically. Body text NOT read (multiple
+IA identifier attempts returned 404 on 2026-04-30; MACBA website not
+in the WebFetch allowlist). The title — *Public Photographic Spaces:
+Exhibitions of Propaganda, from* Pressa *to the* Family of Man,
+*1928–55* — is itself the strongest indication of its argument: that
+*Family of Man* is the closing term in a tradition beginning with
+Soviet and German interwar political-photography exhibitions. This
+adds a third axis to the 2000s critical map, distinct from both
+Barthes (myth criticism) and Stimson (audience-response
+phenomenology).
+
+These three sources redraw the geographic distribution of the
+reception thread, which through the 1970s and 1980s had been
+predominantly Anglophone (see those decades' perspective notes).
+
+## 5. The wider 2000s photography-theory field
+
+Three 2000s monographs sit in the immediate background of the
+*Family of Man* re-reading without addressing the exhibition
+directly: Geoffrey Batchen, *Each Wild Idea* (MIT Press, 2001)
+[src-batchen-2001-each-wild-idea]; Ariella Azoulay, *Death's
+Showcase* (MIT Press, 2001) and *The Civil Contract of Photography*
+(Zone Books, 2008) [src-azoulay-2001-deaths-showcase,
+src-azoulay-2008-civil-contract]; and James Elkins (ed.),
+*Photography Theory* (Routledge, 2007)
+[src-elkins-2007-photography-theory].
+
+Azoulay's "civil contract" framework — the photograph as an event
+constituted by a three-way relation among photographer, subject, and
+viewer — is the decade's most influential new theoretical vocabulary
+for photographic spectatorship, and sits in the same conceptual
+neighbourhood as Stimson's question about *Family of Man* (what does
+it mean to position a mass audience as spectators of strangers?). The
+specific connection to *Family of Man* in Azoulay's text is not
+confirmed from body-text access in this round. The Elkins entry is
+itself flagged as bibliographically unconfirmed (the Wikipedia
+article on Elkins fetched 2026-04-30 did not list this title).
+The 2000 founding of the journal *Grey Room* (MIT Press)
+[src-grey-room-founded-2000] also belongs in the decade's
+critical-theory infrastructure; no specific *Family of Man* article
+has been identified there in this round.
+
+## 6. The UNESCO inscription effect (2003)
+
+In April 2003 the *Family of Man* collection at Clervaux was
+inscribed on the UNESCO Memory of the World International Register,
+following a 2002 nomination by Luxembourg
+[src-unesco-mow-2003, src-unesco-mow-nomination-en-2002,
+src-unesco-mow-nomination-fr-2002]. This is the institutional
+event of the decade for the exhibition's afterlife.
+
+The full institutional account is in `research/unesco.md` and is not
+duplicated here. The points relevant to the reception thread are:
+
+- The inscription canonises a specific set of figures for the
+  exhibition: 503 photographs, 273 photographers, 68 countries, 32
+  themes [src-unesco-mow-2003, fetched 2026-04-29]. The "32 themes"
+  count differs from the CNA Luxembourg education portal's "37
+  themes" figure — a discrepancy documented in `research/sections.md`
+  and not relitigated here.
+- The inscription's justification language ("courageous and
+  provocative," "the memory of an entire era, that of the Cold War
+  and McCarthyism") explicitly engages the political context that
+  Barthes and Sekula also engage, while framing it as part of the
+  exhibition's significance rather than as its limitation
+  [src-unesco-mow-2003]. This formulation is the institution's
+  acknowledgement that the show is contested without being a
+  retraction of its world-heritage standing.
+- Inscription is recognition, not legal protection. UNESCO does not
+  confer ownership or impose conservation obligations. Title remains
+  with CNA Luxembourg / the Luxembourg state. The 2010–2013
+  restoration was carried out on an already-inscribed collection, but
+  inscription itself did not require it.
+
+The inscription effect on critical reception is paradoxical. On one
+reading the inscription strengthens the exhibition's institutional
+standing and helps explain the cluster of fiftieth-anniversary
+scholarship in 2004–2006. On another reading it gives the
+*October*-axis critique fresh purchase: the exhibition that Barthes
+and Sekula attacked for naturalising history is now formally
+inscribed by an inter-governmental cultural body as documentary
+heritage of "world significance and outstanding universal value."
+The 2002 nomination forms remain unread in this project (denied in
+the previous round; not re-attempted this round).
+
+## 7. Where the 2000s reading sits relative to the 1980s critique
+
+The relationship between the *October*-axis 1980s critique and the
+2000s re-reading is not a simple overturning. The 1980s critique, on
+Phillips's reading, showed that MoMA under Steichen and Szarkowski
+operated as a "judgment seat" canonising photography on
+aestheticist-modernist terms incompatible with a politically-attentive
+reading [src-phillips-1982-judgment-seat]; on Sekula's reading, that
+*The Family of Man* was ideologically continuous with US Cold War
+cultural diplomacy [src-sekula-1981].
+
+The 2000s re-reading — at the level of secondary characterisation,
+given that Stimson's body text is unread this round — shifts register.
+Stimson 2006 is widely paraphrased (caa.reviews Vettel-Becker review;
+multiple secondary summaries surfaced 2026-05-07) as moving the
+analytic frame from the curators' intentions to the audience's
+phenomenological response — the moment of "pivot" where a viewer
+inserts themselves between two photographs. If the paraphrases are
+accurate, this does not refute the *October* reading; it operates at
+a different scale [src-vettel-becker-caa-reviews-stimson-kaplan;
+reading not yet confirmed against Stimson's own text]. Back /
+Schmidt-Linsenhoff 2004's "Humanism and Postmodernism: a reappraisal"
+framing similarly suggests a position to the side of, rather than in
+opposition to, the 1980s critique. Ribalta 2008 places *Family of
+Man* in a genealogy of political-photography exhibitions running
+back to 1928 *Pressa* — a flank movement on Sekula's argument, not a
+denial of it [src-ribalta-2008-public-photographic-spaces].
+
+A cautious summary: the 2000s scholarship is best characterised as a
+"reappraisal" decade rather than a "rehabilitation" decade. None of
+the four 2004–2008 titles is naively pro-*Family of Man*; none is
+dismissive in the *October*-axis manner. They re-open the exhibition
+as an object of analysis without pre-committing to a verdict. This
+characterisation rests on titles, editorial introductions, and
+reviewer summaries; it should be checked against the source texts
+themselves in a future pass.
+
+## 8. The 2000s catalog and CNA institutional output
+
+MoMA has reprinted the 1955 catalog multiple times. A post-2000
+anniversary edition is widely cited in 2000s scholarship, though the
+specific edition year and ISBN circulating in the 2000s have not been
+confirmed from any source fetched in this project so far
+[src-fom-catalog-50th-anniversary-2004]; the CNA education portal
+fetched 2026-04-30 lists the catalog with year 2013, which may
+indicate the most recent reprint rather than an anniversary edition
+specifically.
+
+The Steichen Collections CNA portal (fetched 2026-05-07) records the
+1990s restoration in collaboration with Studio Berselli, Milan, and
+notes that "a second restoration period followed the closure of the
+museum in the years 2010-2013." For the decade in question
+(2000–2009) the CNA institutional voice is quieter than for 1994
+(inauguration), 2003 (UNESCO inscription), or 2013 (re-opening): the
+2000s are a period of public display under inscribed status rather
+than a period of major institutional events. No CNA monograph or
+major scholarly publication beyond the Back / Schmidt-Linsenhoff 2004
+volume has been identified in this round.
+
+Brandow & Ewing, *Edward Steichen: Lives in Photography* (MoMA,
+2008) [src-brandow-ewing-2008-steichen-lives] sits at the end of the
+decade as the major institutional re-engagement with Steichen as
+figure rather than with *Family of Man* as exhibition. Body text not
+read in this round.
+
+## 9. What this essay does not claim, and what is left open
+
+Per the museum-grade-accuracy rule, this essay does **not** quote
+verbatim phrasing from Stimson 2006, Back / Schmidt-Linsenhoff 2004,
+Ribalta 2008, Lugon 2001, Elkins 2007, Brandow & Ewing 2008, or the
+*History of Photography* 2005 special issue beyond what is captured
+in the corresponding source files. Body texts of all of these were
+either access-restricted (IA controlled digital lending),
+permission-denied (caareviews, tandfonline, mitpress, philpapers),
+or not located in this round. The Vettel-Becker caa.reviews review of
+Stimson + Kaplan is identified by reviewer name and URL via Google
+search snippet only; characterisations of Stimson's argument that
+descend from it are at the level of secondary summary
+[src-vettel-becker-caa-reviews-stimson-kaplan]. The relationship
+between the 2000s re-reading and the 1980s *October*-axis critique
+is described as "a flank movement / different register," not as a
+refutation. Specific page numbers from any 2000s monograph are not
+cited because no body text was opened in this round.
+
+Highest-priority open follow-ups: a controlled-digital-lending
+borrow of Stimson 2006 on Internet Archive
+(`pivotofworldphot00stim`); body access to Back / Schmidt-Linsenhoff
+2004; a library fetch of the *History of Photography* 29:4 (2005)
+special issue introduction (Hoffman, pp. 317–319) and lead articles;
+direct fetch of the caa.reviews Vettel-Becker review; and the 2002
+UNESCO nomination forms (English and French PDFs linked from the
+register page, denied in the previous round).
+
+## Cross-reference
+
+This essay pairs with:
+
+- `research/reception-1950s-us-press.md` — verification-status framing
+  of the 1950s US-press slice.
+- `research/reception-1970s-critical-theory.md` — Anglophone
+  critical-theory turn.
+- `research/reception-1980s-critical-theory.md` — *October*-axis
+  consolidation.
+- `research/reception-1990s-clervaux-installation.md` — Clervaux
+  inauguration, Sandeen 1995, mid-decade peer reception.
+- `research/unesco.md` — institutional account of the 2003 Memory of
+  the World inscription (full).
+- `research/clervaux.md` — custodial history at the CNA.
+
+## Citation provenance summary
+
+All bibliographic claims rest on (i) source files in `sources/2000s/`,
+(ii) Internet Archive metadata fetches recorded in those files, and
+(iii) Google search snippets to publisher / journal / review pages
+where direct WebFetch was denied this round. No verbatim text from
+Stimson 2006, Back / Schmidt-Linsenhoff 2004, Ribalta 2008, Lugon
+2001, Elkins 2007, Brandow & Ewing 2008, or the 2005 *History of
+Photography* special issue is quoted because no body text was
+successfully fetched. The UNESCO 2003 inscription claims rest on
+`research/unesco.md` (2026-04-29 fetches retained in
+`src-unesco-mow-2003`). The CNA institutional voice rests on the
+Steichen Collections CNA portal fetched 2026-05-07.

--- a/sources/2000s/history-of-photography-2005-fom-special-issue.md
+++ b/sources/2000s/history-of-photography-2005-fom-special-issue.md
@@ -1,0 +1,44 @@
+---
+id: src-history-of-photography-2005-fom-special-issue
+title: "The Family of Man: An introduction (and special issue contents)"
+author: "Hoffman, Katherine (issue introduction); various"
+year: 2005
+type: article
+publisher: "Taylor & Francis (Routledge), London"
+url: "https://www.tandfonline.com/doi/abs/10.1080/03087298.2005.10442813"
+accessed: 2026-05-07
+tier: 2
+language: en
+verified: false
+tags: [scholarship, history-of-photography, journal, special-issue, 2005, fiftieth-anniversary, reception]
+---
+
+## Citation
+
+Hoffman, Katherine. "The Family of Man: An introduction." *History of Photography*, vol. 29, no. 4 (Winter 2005), pp. 317–319. DOI: 10.1080/03087298.2005.10442813. Issue is the journal's fiftieth-anniversary special issue on *The Family of Man*.
+
+A second article in the same issue, located via the same Taylor & Francis DOI structure during this round:
+
+- Anonymous (search-result attribution; reviewer not named on the search-snippet page), "Sowing the seeds / setting the stage: Steichen, Stieglitz and *The Family of Man*," *History of Photography*, vol. 29, no. 4 (2005). DOI: 10.1080/03087298.2005.10442814. Pages NOT confirmed from a fetched source this round.
+
+## Tier justification
+
+Tier 2: peer-reviewed scholarly journal (*History of Photography*, Routledge / Taylor & Francis), explicitly listed in `CREDIBILITY.md` among Tier-2 journals. The 2005 issue is a dedicated special issue marking the fiftieth anniversary of the exhibition's 1955 opening at MoMA — i.e., the most concentrated single block of peer-reviewed scholarly engagement with *The Family of Man* in the 2000s.
+
+## Relevance
+
+The 2005 *History of Photography* special issue is the central peer-reviewed venue in which the 2000s revisitation of *The Family of Man* unfolded in Anglophone scholarship. Issue confirmed via Taylor & Francis DOI metadata fetched 2026-05-07 (DOIs 10.1080/03087298.2005.10442813 and 10.1080/03087298.2005.10442814 surfaced through web search snippets to Taylor & Francis Online). The issue framing — fifty years after MoMA 1955 — explains the 2000s scholarly cluster (Back/Schmidt-Linsenhoff 2004, Stimson 2006) chronologically.
+
+Hoffman's introduction (per the Google search snippet shown 2026-05-07): "The exhibition The Family of Man, curated by Edward Steichen with the assistance of Wayne Miller, opened at the Museum of Modern Art (New York) on 25 January 1955" and notes that "various scholars have examined the history of the exhibition and its cultural and political meaning over the past five decades, and the exhibit merits renewed exploration as it surpasses its fiftieth anniversary." (Snippet text only; full article body NOT fetched this round.)
+
+## Key excerpts / pages
+
+- **Access status (2026-05-07):** Tandfonline DOI page returned permission-denied via WebFetch this round. The article abstract / body was NOT read. Bibliographic data (volume, issue, year, journal, DOI, opening sentences quoted above) is from a Google search snippet to the Taylor & Francis page, fetched 2026-05-07.
+- Full article text NOT confirmed. No further quotations recorded.
+
+## Notes
+
+- `verified: false`: full-text not accessed; bibliographic core (journal, volume, issue, year, DOI, author, opening sentences of introduction) confirmed via search-snippet only.
+- A future pass should: (1) complete a tandfonline / library-proxy fetch of the introduction and at least one substantive article; (2) confirm the full table of contents of the issue; (3) note which contributors engage Barthes, Sekula, Sontag, Sandeen, or Stimson directly.
+- The 2005 special issue is conceptually paired with the 2004 Back/Schmidt-Linsenhoff bilingual volume (`src-back-schmidt-linsenhoff-2004`) and Stimson 2006 (`src-stimson-2006`). All three sit within an 18-month-wide cluster of scholarly fiftieth-anniversary engagement.
+- Perspective: critical / historical.

--- a/sources/2000s/vettel-becker-caa-reviews-stimson-kaplan.md
+++ b/sources/2000s/vettel-becker-caa-reviews-stimson-kaplan.md
@@ -1,0 +1,39 @@
+---
+id: src-vettel-becker-caa-reviews-stimson-kaplan
+title: "Review of Louis Kaplan, *American Exposures* (2005), and Blake Stimson, *The Pivot of the World* (2006)"
+author: "Vettel-Becker, Patricia"
+year: ~
+type: article
+publisher: "caa.reviews (College Art Association)"
+url: "https://caareviews.org/reviews/1074"
+accessed: 2026-05-07
+tier: 2
+language: en
+verified: false
+tags: [book-review, scholarship, stimson, kaplan, family-of-man, photography-theory, 2000s, peer-review]
+---
+
+## Citation
+
+Vettel-Becker, Patricia. Review of *American Exposures: Photography and Community in the Twentieth Century* by Louis Kaplan, and *The Pivot of the World: Photography and Its Nation* by Blake Stimson. *caa.reviews* (College Art Association). [Date NOT confirmed from a source fetched this round; reviewer affiliation: Associate Professor, Department of Art, Montana State University-Billings, per a Google search snippet returned 2026-05-07.] URL: https://caareviews.org/reviews/1074.
+
+## Tier justification
+
+Tier 2: scholarly peer-reviewed book review on the College Art Association's online review platform (caa.reviews), authored by a named academic reviewer. CAA is the principal North American learned society for the visual arts and art history; its book-review platform is the standard peer-reviewed venue for art-historical reviews in the United States.
+
+## Relevance
+
+The single named, identifiable peer-reviewed review of Blake Stimson, *The Pivot of the World* (MIT Press, 2006), located in this round of source-finding. The review is a joint review of Kaplan's *American Exposures* (2005) and Stimson's *Pivot* — i.e., it situates Stimson within the immediate 2005–2006 cohort of post-2000 re-readings of mid-century American photographic culture. Vettel-Becker's reading is therefore the closest thing this repository has, in this round, to a contemporary scholarly evaluation of Stimson's *Family of Man* chapter from within the photography-criticism field.
+
+## Key excerpts / pages
+
+- **Access status (2026-05-07):** caareviews.org WebFetch was attempted in this round and returned a permission-denied response. The body text of the review was therefore NOT directly fetched this round. The reviewer's name (Patricia Vettel-Becker), affiliation (Associate Professor, Department of Art, Montana State University-Billings), and the joint-review framing (Kaplan + Stimson) are from a Google search snippet returned 2026-05-07. The exact publication date of the review on caa.reviews has NOT been confirmed.
+- The web-search summary (Google, 2026-05-07) further reports that the review notes Stimson "uses three case studies to make one overarching argument and focuses primarily on the 1950s," and that he treats *The Family of Man*, Robert Frank's *The Americans*, and Bernd and Hilla Becher's typological photographs as the three case studies. These characterizations are search-snippet-derived and have NOT been confirmed against the full review body in this round.
+- No verbatim quotations from the review body are recorded here. Any quotation must wait on a direct fetch.
+
+## Notes
+
+- `verified: false`: full text not accessed; bibliographic identification rests on a search-snippet attribution to caa.reviews and on the Google-summary identification of the reviewer as Patricia Vettel-Becker (Montana State University-Billings).
+- A future pass should: (1) fetch the review body directly via caa.reviews when allowlist permits; (2) confirm the publication date on the caa.reviews record; (3) extract any direct verbatim characterization of Stimson's argument about *The Family of Man*; (4) note whether Vettel-Becker engages Sekula, Phillips, Barthes, or Sandeen in her evaluation.
+- Cross-reference to `src-stimson-2006`: the book under review.
+- Perspective: critical (peer review).


### PR DESCRIPTION
## Summary

- Seeds the first 50 held-out evaluation questions in `training/eval/eval.jsonl`, drawing only from material already merged in `research/`, `sources/`, and `data/`.
- Adds `training/eval/README.md` documenting the held-out invariant, distribution, difficulty mix, and the addition workflow.
- All four pre-merge checks pass: `validate_schema.py`, `check_credibility.py`, `check_injection_patterns.py`, and `audit_dataset.py training/eval/eval.jsonl`.

## Distribution

| `eval_category`     | Count | Share |
|---------------------|-------|-------|
| photographer        | 14    | 28%   |
| catalog             | 8     | 16%   |
| tour                | 8     | 16%   |
| clervaux            | 5     | 10%   |
| unesco              | 5     | 10%   |
| reception           | 5     | 10%   |
| exhibition-history  | 3     | 6%    |
| sections            | 2     | 4%    |
| **Total**           | **50**| **100%** |

Max category share: 28% (under the 30% rule).

Difficulty mix: 8 easy, 24 medium, 18 hard.

Critical-perspective floor (interpretive `topic`s only): 5/10 = 50%, well above the 25% target enforced in `audit_dataset.py`.

## Held-out integrity

`training/dataset.jsonl` is empty; `training/curated/` and `training/raw/` do not exist. No verbatim duplication is possible at v0.1 seed time. All eval IDs (`eval-00001` … `eval-00050`) and all user-message strings are unique.

## Test plan

- [x] `python3 scripts/validate_schema.py` — schema OK
- [x] `python3 scripts/check_credibility.py` — every cited `src-…` resolves
- [x] `python3 scripts/check_injection_patterns.py` — no injection markers
- [x] `python3 scripts/audit_dataset.py training/eval/eval.jsonl` — audit OK
- [x] `tvl-tech-bias-validator` skill audited the seed; main session resolved one row (`eval-00021`, Doisneau plate count) where the data CSV (5 rows) extended beyond the photographer-bio note (3 rows in Section 2 Lovers); the row now reports both.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)