### PR TITLE
Harness upgrade for Claude Code v2.1.121–v2.1.133+: drop worktree-deny rule, add post-merge hook, recommend autoMode.hard_deny

### DIFF
--- a/.claude/hooks/post-merge-curator.sh
+++ b/.claude/hooks/post-merge-curator.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# .claude/hooks/post-merge-curator.sh
+#
+# PostToolUse hook that logs merged PRs as candidates for the dataset-curator
+# pipeline. Per plan.md §5, the dataset-curator should propose training examples
+# after every merge of a source/research/data-touching PR. This hook writes one
+# entry per merge to a queue file; a future scheduled agent (or manual
+# /dataset-curator invocation) consumes the queue and opens a curation issue.
+#
+# Activation (per-user, in ~/.claude/settings.local.json or .claude/settings.local.json):
+#
+#   {
+#     "hooks": {
+#       "PostToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [
+#             { "type": "command",
+#               "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/post-merge-curator.sh" }
+#           ]
+#         }
+#       ]
+#     }
+#   }
+#
+# Hook input (stdin) is the JSON event Claude Code sends for PostToolUse. We
+# look for `tool_input.command` matching `gh pr merge`. On match, append a
+# JSONL line to .claude/dataset-curator-queue.jsonl with the PR number, branch,
+# files changed, and timestamp.
+#
+# This hook is intentionally minimal: it does NOT spawn an agent or call gh
+# itself. The point is to capture the event for batch processing, not to
+# expand the blast radius of every git operation.
+
+set -euo pipefail
+
+# Read the hook input from stdin
+input="$(cat)"
+
+# Extract the bash command that just ran. If jq is not available, fall back to
+# grep — but jq is the standard tool for hook payloads.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "post-merge-curator: jq not available; skipping" >&2
+  exit 0
+fi
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+
+# Only act on `gh pr merge` invocations. Match conservatively — the merge
+# command can take various forms (with --squash, --merge, --rebase, etc.) but
+# the literal substring "gh pr merge" is reliable.
+if ! printf '%s' "$cmd" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+merge\b'; then
+  exit 0
+fi
+
+# Project root (Claude Code sets CLAUDE_PROJECT_DIR for hooks).
+project_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+queue_file="$project_dir/.claude/dataset-curator-queue.jsonl"
+
+# Extract PR number from the command if present (`gh pr merge 123 --squash`).
+pr_number=$(printf '%s' "$cmd" | grep -oE '\bgh[[:space:]]+pr[[:space:]]+merge[[:space:]]+[0-9]+' | grep -oE '[0-9]+$' || echo "")
+
+# Capture context. Errors here should not block the merge; redirect to /dev/null.
+timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+branch=$(git -C "$project_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+last_commit=$(git -C "$project_dir" log -1 --format=%H 2>/dev/null || echo "")
+files=$(git -C "$project_dir" log -1 --format= --name-only 2>/dev/null | tr '\n' ';' || echo "")
+
+# Append a JSONL line. Use jq to ensure correct escaping.
+jq -n \
+  --arg ts "$timestamp" \
+  --arg pr "$pr_number" \
+  --arg branch "$branch" \
+  --arg sha "$last_commit" \
+  --arg files "$files" \
+  --arg cmd "$cmd" \
+  '{event: "pr_merged", ts: $ts, pr: $pr, branch: $branch, sha: $sha, files: $files, cmd: $cmd}' \
+  >> "$queue_file"
+
+# Log to stderr for visibility in the harness transcript (Claude Code captures
+# hook stderr in its event stream).
+echo "post-merge-curator: queued PR #${pr_number:-?} for dataset-curator (queue: $queue_file)" >&2

--- a/.claude/settings.recommended.json
+++ b/.claude/settings.recommended.json
@@ -1,0 +1,90 @@
+// Recommended additions to your local .claude/settings.local.json (gitignored).
+// This file is committed as a *reference* — copy the relevant blocks into your
+// own settings.local.json. Do NOT rename this to settings.json or
+// settings.local.json directly; Claude Code will not load it.
+//
+// Last reviewed: 2026-05-08, against Claude Code v2.1.132–v2.1.133+.
+//
+// Sections:
+//   1. autoMode.hard_deny  — destructive-action blocks (requires v2.1.133+)
+//   2. worktree.baseRef    — reproducible worktree base ref (requires v2.1.133+)
+//   3. hooks.PostToolUse   — post-merge dataset-curator queue (works on v2.1.121+)
+//
+// Strip the // comments before copying — JSON does not support them.
+{
+  // --------------------------------------------------------------------------
+  // 1. autoMode.hard_deny — guardrails that block unconditionally regardless of
+  // user intent or allow exceptions. Requires Claude Code v2.1.133+ (May 7).
+  //
+  // These mirror the destructive-action rules currently documented in
+  // CLAUDE.md prose. Putting them here makes the harness enforce them rather
+  // than relying on Claude's own restraint.
+  // --------------------------------------------------------------------------
+  "autoMode": {
+    "allow": ["$defaults"],
+    "hard_deny": [
+      {
+        "tool": "Bash(git push --force *)",
+        "reason": "Force-push is destructive; never auto-allowed. Use --force-with-lease only with explicit user approval."
+      },
+      {
+        "tool": "Bash(git push *--no-verify*)",
+        "reason": "Bypassing git hooks defeats the validator gate. CLAUDE.md forbids --no-verify."
+      },
+      {
+        "tool": "Bash(git commit *--no-verify*)",
+        "reason": "Same as above — pre-commit hooks are part of the museum-grade-accuracy stack."
+      },
+      {
+        "tool": "Bash(git reset --hard *)",
+        "reason": "--hard reset destroys uncommitted work. Use git stash + soft reset instead, or get explicit user approval."
+      },
+      {
+        "tool": "Bash(rm -rf *)",
+        "reason": "Always confirm with the user before recursive delete."
+      },
+      {
+        "tool": "Bash(gh pr merge * main *)",
+        "reason": "Direct merges of third-party branches into main require explicit user authorization."
+      }
+    ],
+    "environment": ["$defaults"]
+  },
+
+  // --------------------------------------------------------------------------
+  // 2. worktree.baseRef — control whether agent-isolation worktrees branch
+  // from origin/<default> ("fresh") or local HEAD ("head"). Default in
+  // v2.1.133+ is "fresh", which gives reproducible PR cycles when the parent
+  // session has uncommitted changes. Requires v2.1.133+.
+  // --------------------------------------------------------------------------
+  "worktree": {
+    "baseRef": "fresh"
+  },
+
+  // --------------------------------------------------------------------------
+  // 3. hooks.PostToolUse — post-merge dataset-curator queue.
+  //
+  // Works on Claude Code v2.1.121+. The hook script lives in the repo at
+  // .claude/hooks/post-merge-curator.sh and is committed; it logs every
+  // `gh pr merge` invocation to .claude/dataset-curator-queue.jsonl
+  // (gitignored) for batch processing by a future scheduled
+  // dataset-curator agent.
+  //
+  // The hook does NOT spawn an agent or open issues itself — it only
+  // captures events. This keeps the blast radius of every git operation
+  // small.
+  // --------------------------------------------------------------------------
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/post-merge-curator.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env.local
 *.env.local
 .claude/worktrees/
+.claude/dataset-curator-queue.jsonl

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,40 @@ For each claim you add to a source file, research note, or CSV `notes` field, yo
 
 Any "no" → the claim does not go in the file.
 
-## Subagent spawning — worktree permission caveat
+## Subagent spawning — worktree status (updated 2026-05-08)
 
-Subagents spawned with `isolation: worktree` + `run_in_background: true` do not currently inherit this repo's `.claude/settings.local.json` allowlist. The `bypassPermissions` spawn mode does not propagate to the worktree tool layer. As of 2026-04-24, the workaround is to do short source-verification work directly in the main session until a `SubagentStart` hook is added to copy settings into new worktrees.
+Earlier rounds (April 2026) avoided `isolation: worktree` for source-touching subagents because the worktree tool layer denied Bash/WebFetch/Edit even with `bypassPermissions`. Two upstream Claude Code fixes have since landed that should resolve this:
+
+- **v2.1.98 (April 9, 2026)** — "Fixed agent team members not inheriting leader's permission mode when using `--dangerously-skip-permissions`."
+- **v2.1.121 (April 28, 2026)** — "Fixed subagents with worktree isolation leaking working directory back to parent session's Bash tool." This was the proximate cause of the branch-contention bug observed across 5+ parallel runs in early May 2026 (workers' `git checkout` flipped the parent session's working tree).
+
+**Current recommendation (as of 2026-05-08):** worktree-isolated parallel subagents should now work as intended. Validate with a small read-only spawn before relying on it for batch work, and confirm the Claude Code binary is at v2.1.121 or later (`claude --version`). On v2.1.133+ the new `worktree.baseRef` setting (`fresh` | `head`) controls whether the worktree branches from `origin/<default>` or local `HEAD` — set to `fresh` for reproducible PR cycles.
+
+**Fallback** (if validation fails on this machine's Claude Code build): keep doing source-touching work in the main session, as documented in earlier rounds.
+
+## Post-merge dataset-curator hook
+
+A `PostToolUse` hook script lives at `.claude/hooks/post-merge-curator.sh` and is invoked when `Bash(gh pr merge ...)` runs. It captures the PR number, branch, SHA, and changed files into `.claude/dataset-curator-queue.jsonl` (gitignored). A future scheduled `dataset-curator` agent (or manual `/dataset-curator` invocation) consumes the queue and opens a `training-curation` GitHub issue.
+
+Activation is per-user — register in your own `.claude/settings.local.json` or `~/.claude/settings.local.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/post-merge-curator.sh" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The hook does NOT spawn an agent; it logs the event for batch processing. Per the project's risk-management posture, expanding the blast radius of every git operation is more costly than missing one merge in the queue.
 
 ## Prompt-injection defense
 


### PR DESCRIPTION
## Summary

Three changes that align this repo's Claude Code harness with Anthropic's April–May 2026 changelog (https://code.claude.com/docs/en/changelog):

### 1. `CLAUDE.md` — drop the worktree-deny rule

The April 24 caveat advising against `isolation: worktree` subagents was correct *at the time* but the two upstream bugs that motivated it have shipped fixes:

- **v2.1.98 (Apr 9, 2026)** — agent team members inherit leader's permission mode under `--dangerously-skip-permissions`
- **v2.1.121 (Apr 28, 2026)** — fixed subagents with worktree isolation leaking working directory back to the parent session's Bash tool. **This is the proximate cause of the branch-contention bug observed in 5+ parallel runs in early May 2026** (workers' `git checkout` flipped the parent session's branch under it).

CLAUDE.md now says: validate before relying, and on v2.1.133+ set `worktree.baseRef: fresh` for reproducible PR cycles.

### 2. `.claude/hooks/post-merge-curator.sh` — implement the missing dataset-curator trigger

`plan.md` §5 documents that "Dataset Curator runs on merge, proposes training examples → curation batch issue → your approval." The claude-coach audit earlier this session caught that this never actually fires automatically — it's only ever happened when a session explicitly calls it.

This commit adds a `PostToolUse` hook script that captures every `gh pr merge` event (PR #, branch, SHA, changed files) into `.claude/dataset-curator-queue.jsonl` (gitignored). A future scheduled dataset-curator agent (or manual `/dataset-curator` invocation) consumes the queue.

The hook does **not** spawn an agent or open issues directly — it only logs events. Per the project's risk posture, expanding the blast radius of every git operation costs more than missing one merge in the queue.

Activation is per-user via `.claude/settings.local.json`'s `hooks.PostToolUse` block (see `.claude/settings.recommended.json`).

### 3. `.claude/settings.recommended.json` — reference settings file

A committed reference (not loaded by Claude Code) documenting the three blocks worth adding to per-user settings.local.json:

- `autoMode.hard_deny` rules for destructive operations (force-push, `--no-verify`, `rm -rf`, etc.) — currently in CLAUDE.md prose, would be enforced by the harness on v2.1.133+
- `worktree.baseRef: fresh` — v2.1.133+
- the `PostToolUse` hook registration — works on v2.1.121+

## Test plan

- [ ] Recipient runs `claude --version` to confirm ≥ v2.1.121 (post-merge hook prerequisite). v2.1.133+ unlocks the `autoMode.hard_deny` and `worktree.baseRef` features.
- [ ] After upgrading, validate `isolation: worktree` parallel subagents work as intended with a small read-only spawn.
- [ ] Activate the hook in personal `.claude/settings.local.json` (snippet in `.claude/settings.recommended.json`); merge a small test PR and confirm `.claude/dataset-curator-queue.jsonl` gets a new line.
- [ ] (Optional) Copy `autoMode.hard_deny` block into personal settings; verify it blocks `git push --force` while allowing routine pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)