### PR TITLE
Reception 1960s essay: Sandburg/Steichen deaths + Szarkowski transition

### DIFF
--- a/research/reception-1960s-szarkowski-transition.md
+++ b/research/reception-1960s-szarkowski-transition.md
@@ -1,0 +1,698 @@
+---
+title: "1960s reception: Sandburg/Steichen deaths, Szarkowski transition, and the curatorial pivot away from humanist exhibition-making"
+status: draft
+last_updated: 2026-05-09
+perspective: [historical, institutional, critical]
+contested: true
+sources:
+  - src-moma-1961-steichen-the-photographer
+  - src-moma-1962-szarkowski-appt
+  - src-moma-1962-bitter-years-exhibition
+  - src-steichen-1963-life
+  - src-nyt-1963-life-review
+  - src-szarkowski-1964-photographers-eye-exh
+  - src-moma-1964-photography-galleries
+  - src-szarkowski-1966-photographers-eye-book
+  - src-szarkowski-1967-new-documents
+  - src-usia-fom-tour-wind-down
+  - src-usia-fom-copy3-luxembourg-1965
+  - src-steichen-1966-luxembourg-visit
+  - src-cna-fom-steichencollections
+  - src-icp-1966-concerned-photography-fund-institutional
+  - src-wikipedia-cornell-capa-concerned-photographer-pointer
+  - src-wikipedia-sandburg-1967-death-pointer
+  - src-wikipedia-steichen-1962-retirement-pointer
+  - src-wikipedia-fom-copies-pointer
+  - src-aperture-1969-steichen
+fresh_fetches_this_round: []
+in_session_reads:
+  - "sources/1960s/szarkowski-1964-photographers-eye-exh.md (read 2026-05-09)"
+  - "sources/1960s/szarkowski-1966-photographers-eye-book.md (read 2026-05-09)"
+  - "sources/1960s/szarkowski-1967-new-documents.md (read 2026-05-09)"
+  - "sources/1960s/moma-1962-szarkowski-appointment.md (read 2026-05-09)"
+  - "sources/1960s/moma-1962-bitter-years-exhibition.md (read 2026-05-09)"
+  - "sources/1960s/moma-1961-steichen-the-photographer.md (read 2026-05-09)"
+  - "sources/1960s/moma-1964-photography-galleries-opening.md (read 2026-05-09)"
+  - "sources/1960s/steichen-1963-life-in-photography.md (read 2026-05-09)"
+  - "sources/1960s/nyt-1963-steichen-life-in-photography-review.md (read 2026-05-09)"
+  - "sources/1960s/usia-fom-tour-wind-down-1962-1965.md (read 2026-05-09)"
+  - "sources/1960s/usia-fom-copy3-luxembourg-donation-1965.md (read 2026-05-09)"
+  - "sources/1960s/steichen-1966-luxembourg-visit.md (read 2026-05-09)"
+  - "sources/1960s/cna-steichencollections-fom-history.md (read 2026-05-09)"
+  - "sources/1960s/icp-1966-concerned-photography-fund-institutional.md (read 2026-05-09)"
+  - "sources/1960s/wikipedia-cornell-capa-concerned-photographer-pointer.md (read 2026-05-09)"
+  - "sources/1960s/wikipedia-sandburg-1967-death-pointer.md (read 2026-05-09)"
+  - "sources/1960s/wikipedia-steichen-1962-retirement-pointer.md (read 2026-05-09)"
+  - "sources/1960s/wikipedia-fom-tour-copies-pointer.md (read 2026-05-09)"
+  - "sources/1960s/aperture-1969-steichen.md (read 2026-05-09)"
+---
+
+# 1960s reception: Sandburg/Steichen deaths, Szarkowski transition, and the curatorial pivot away from humanist exhibition-making
+
+> **A note on the framing "Szarkowski transition".** The phrase is used
+> here as a convenience handle for the institutional shift from Steichen
+> (Director of Photography 1947–1961, Director Emeritus through 1962) to
+> John Szarkowski (Director of Photography from 1 July 1962 onward) at
+> MoMA's Department of Photography. The phrase does **not** imply that
+> Szarkowski's program was a "successor" to *The Family of Man* in the
+> sense of continuing it; the curatorial point of his first two major
+> exhibitions — *The Photographer's Eye* (1964) and *New Documents*
+> (1967) — was, on the contrary, to define a different program. The
+> existing in-repo source notes for those two exhibitions explicitly mark
+> this as the "post-Steichen" curatorial paradigm
+> [src-szarkowski-1964-photographers-eye-exh; src-szarkowski-1966-photographers-eye-book;
+> src-szarkowski-1967-new-documents]. Whether that shift constitutes a
+> rupture, a depoliticisation, or a sober formalist correction is a
+> contested reading; this essay marks the contestation rather than
+> resolving it (see §6).
+
+This essay accompanies the 1960s bench of source entries
+(`sources/1960s/`) and continues the decade-by-decade reception thread
+established in `research/reception-1950s-us-press.md`,
+`research/reception-1970s-critical-theory.md`,
+`research/reception-1980s-critical-theory.md`,
+`research/reception-1990s-clervaux-installation.md`,
+`research/reception-2000s-stimson-era.md`, and
+`research/reception-2010s-turner-era.md`. It is to be read alongside
+`research/world-tour.md` (the USIA tour record into which this decade's
+wind-down events fit) and `research/clervaux.md` (the custodial history
+that begins with the 1965 Luxembourg donation).
+
+The 1960s are the decade in which *The Family of Man* completes its
+USIA tour, settles institutionally in Luxembourg, loses its prologue
+author (Sandburg, 22 July 1967) and is formally retired by its
+curator (Steichen, who steps down from MoMA between 1961 and the
+October–November 1962 *Bitter Years* exhibition). At MoMA, John
+Szarkowski takes over the Department of Photography (effective 1 July
+1962) and, by 1967, has installed a curatorial program that defines
+itself by what it is not: *not* the thematic-humanist exhibition model
+that *The Family of Man* exemplified. In parallel, Cornell Capa builds
+the institutional vehicle (the International Fund for Concerned
+Photography, founded 1966 per ICP institutional self-record; first
+*Concerned Photographer* exhibition series launched 1967 per
+Wikipedia) that continues the documentary-humanist line outside MoMA.
+The decade is not a verdict on *The Family of Man*; it is the decade
+in which the exhibition's institutional life resolves into three
+distinct afterlives — Luxembourg custody, MoMA-internal supersession,
+and ICP-style continuation.
+
+This essay does not paraphrase Barthes (1957), Sontag (1977), Sekula
+(1981/1986), Phillips (1982), Sandeen (1995), Stimson (2006), or
+Turner (2013) at the level of body text. None of those texts was
+consulted in this round; the corresponding decade essays handle them.
+What this essay can do is reconstruct, from the in-repo 1960s source
+files alone, the institutional events of the decade and mark where
+those events are contested in the longer reception thread.
+
+## 1. The Steichen retirement, 1961–1962
+
+The Wikipedia article on Edward Steichen (re-fetched 2026-05-02 and
+recorded verbatim in `src-wikipedia-steichen-1962-retirement-pointer`)
+states: *"From 1947 to 1961, Steichen served as Director of the
+Department of Photography at New York's Museum of Modern Art."* The
+same source records that Steichen *"announced his retirement in
+1961"* and that he *"hired John Szarkowski to be his successor at the
+Museum of Modern Art on July 1, 1962."* These are pointer-source
+claims and not yet anchored to a primary archival document; the
+underlying MoMA press release (MOMA_1962_0102_99) was fetched
+2026-04-30 as a binary PDF and the interior text was not extractable
+in that session [src-moma-1962-szarkowski-appt]. The essential
+1961-vs-1962 distinction — Steichen *announced* retirement in 1961
+but Szarkowski's effective start date was 1 July 1962 — is internally
+consistent across the two in-repo records (the MoMA press-release
+entry and the Wikipedia pointer), but should be promoted to direct
+archival verification in a future round.
+
+Two MoMA exhibition events bracket the transition:
+
+- **March–May 1961.** *Steichen the Photographer* (28 March – 30
+  May 1961), curated with a biographical outline by Grace M. Mayer
+  [src-moma-1961-steichen-the-photographer]. This was Steichen's only
+  solo show during his entire MoMA directorship and functions as the
+  institutional retirement marker. The MoMA exhibition page returned
+  HTTP 403 in the 2026-04-30 round and the press release PDF
+  (MOMA_1961_0047_43) was fetched as a binary; the dates above are
+  confirmed via web search returning moma.org metadata.
+- **October–November 1962.** *The Bitter Years 1935–1941: Rural
+  America as Seen by the Photographers of the Farm Security
+  Administration* (18 October – 25 November 1962), with Steichen
+  serving as **Director Emeritus** [src-moma-1962-bitter-years-exhibition;
+  dates and "Director Emeritus" framing verbatim from
+  `src-wikipedia-steichen-1962-retirement-pointer`]. *The Bitter
+  Years* re-presented Roy Stryker's Depression-era FSA archive
+  (Walker Evans, Dorothea Lange, Arthur Rothstein, Jack Delano, Ben
+  Shahn, Russell Lee, et al.) as a documentary record of American
+  hardship; the photographer roster is from secondary literature and
+  not re-verified against a fetched MoMA primary source this round.
+
+The seven-year gap between *The Family of Man* (1955) and *The Bitter
+Years* (1962) tracks Steichen's curatorial arc from a global
+humanist-universalist montage to a historically specific national
+documentary statement — a contrast that figures in 1960s and later
+reception of his MoMA tenure. The precise interpretive weight of that
+contrast is a matter for the secondary literature (Sandeen 1995 was
+not re-read this round; the Sandeen-on-Bitter-Years claim is carried
+from prior rounds and is documented in `research/clervaux.md`, not
+re-litigated here).
+
+A point worth flagging: the 1962 exhibition would itself be donated
+to Luxembourg and is today permanently installed at the Dudelange
+Waassertuerm under CNA stewardship [src-moma-1962-bitter-years-exhibition,
+notes section]. *The Bitter Years* and *The Family of Man*
+travel into Luxembourg together as a paired Steichen bequest.
+
+## 2. The USIA tour wind-down, 1962–1965
+
+The USIA world tour of *The Family of Man* operated through four
+copies circulating simultaneously. Wikipedia's *Family of Man*
+article (fetched 2026-04-30, re-recorded verbatim at
+`src-wikipedia-fom-copies-pointer`) gives the dispersal record:
+
+| Copy | Route | Circulated | Fate |
+|------|-------|-----------|------|
+| Copy 1 | European circulation | — | Dispersed 1962 |
+| Copy 2 | Central America, India, Africa, Middle East | 1955–1963 | Dispersed 1963 |
+| Copy 3 | Second European tour | 1957–1965 | Donated to Luxembourg, 1965 |
+| Copy 4 | South America, Australia, South-East Asia | 1957–1962 | Dispersed 1962 |
+
+This is reproduced in `src-usia-fom-tour-wind-down`. Three copies
+were dispersed within the 1962–1963 window — coincident with
+Steichen's exit from MoMA — and the tour's logistics-management
+phase under USIA effectively ended by 1965, when Copy 3 was
+transferred to Luxembourg. The Wikipedia table claims and the CNA
+institutional summary are mutually consistent on the 1965 Copy-3
+date; NARA RG 306 (the USIA records series) was not consulted this
+round and the underlying primary diplomatic correspondence for the
+transfer has not been fetched.
+
+The CNA's institutional history page records the relevant Luxembourg
+chapter verbatim (fetched 2026-04-30, recorded at
+`src-cna-fom-steichencollections`):
+
+> "the US Government donates the last complete version of the
+> travelling exhibition to Luxembourg" *(timeline marker, 1964–1966
+> period)*
+
+> "Edward Steichen visits his native country and expresses his wish
+> for *The Family of Man* to be exhibited permanently at Clervaux
+> Castle" *(timeline marker, 1964–1966 period)*
+
+The CNA brackets both events into the 1964–1966 window without
+pinning either to a specific year. Wikipedia's Copy-3 line specifies
+1965 for the donation. The "1966 Steichen Luxembourg visit" framing
+in the in-repo file `src-steichen-1966-luxembourg-visit` is carried
+from the brief and is *not* directly confirmed by either pointer
+source: the file is flagged `verified: false` because *Tageblatt* and
+*Luxemburger Wort* coverage was not consulted in any session of this
+project so far.
+
+The transfer is documented in this repo at the level of:
+- Tier 1 institutional event (USIA → Government of Luxembourg) on the
+  basis of the CNA timeline + Wikipedia Copy-3 line
+  [src-usia-fom-copy3-luxembourg-1965, `verified: false`];
+- Tier 1 custodial summary on the CNA-Luxembourg side
+  [src-cna-fom-steichencollections, `verified: true`].
+
+What is *not* documented at primary level: the diplomatic
+correspondence; the transfer agreement text; the specific Luxembourg
+press coverage of either the 1965 transfer or the 1966 Steichen
+visit. All four are open follow-ups for a future round.
+
+The custodial chapter that begins with the 1965 donation continues
+beyond the 1960s: the partial exhibition at Clervaux Castle ran
+1974–1989, the permanent installation was established in 1994, and
+the UNESCO Memory of the World inscription was made in 2003 [all
+recorded verbatim from the CNA timeline at
+`src-cna-fom-steichencollections`]. Those events are handled in
+`research/reception-1990s-clervaux-installation.md`,
+`research/reception-2000s-stimson-era.md`, and `research/clervaux.md`
+respectively, and are not duplicated here.
+
+## 3. The Szarkowski program: *The Photographer's Eye* and *New Documents*
+
+Szarkowski's first two major exhibitions at MoMA define the
+"Szarkowski era" curatorial paradigm. Both are documented in this
+repo's 1960s bench at Tier 1.
+
+### 3.1 *The Photographer's Eye* (1964 exhibition; 1966 book)
+
+Szarkowski's first major exhibition as Steichen's successor opened
+27 May 1964 and closed 23 August 1964 (200 photographs); the
+accompanying book, with 172 photographs reproduced, was published in
+1966 (ISBN 0-87070-527-X) [src-szarkowski-1964-photographers-eye-exh;
+src-szarkowski-1966-photographers-eye-book]. The MoMA calendar page
+and store page returned HTTP 403 in the 2026-04-30 round; the
+exhibition dates, photograph counts, and ISBN are confirmed via
+multiple search-result citations recorded in those entries. The book
+interior was not read in any session of this project so far — the
+five-category framework ("The Thing Itself," "The Detail," "The
+Frame," "Time Exposure," "Vantage Point") is recorded as a list in
+the source file but not quoted from a primary text; the source file
+is marked `verified: false` for that reason.
+
+The repo's in-source framing is direct on the curatorial relation to
+*The Family of Man* [verbatim from
+`src-szarkowski-1964-photographers-eye-exh`, "Relevance" section]:
+
+> "Szarkowski's first major exhibition and programmatic statement as
+> Steichen's successor at MoMA. *The Photographer's Eye* established
+> a formalist, medium-specific framework for evaluating photography
+> — organised around five properties: 'The Thing Itself,' 'The
+> Detail,' 'The Frame,' 'Time Exposure,' and 'Vantage Point.' This
+> framework stands in deliberate counter-position to Steichen's
+> humanist-thematic approach in *The Family of Man* (1955), where
+> images were grouped by social-emotional theme rather than
+> photographic structure."
+
+This is the project's own institutional reading. The same source
+file flags the contested reading: where the descriptive framing
+calls the shift "formalist, medium-specific," the
+*October*-axis reading (Sekula 1981; Phillips 1982; both
+not re-read this round) treats the same shift as
+*depoliticising*. The perspective note appended to the in-repo
+Szarkowski source files explicitly anticipates this contestation
+[verbatim from `src-szarkowski-1964-photographers-eye-exh`]:
+
+> "**Perspective note.** The Steichen→Szarkowski curatorial
+> succession is itself a contested narrative in photography
+> historiography. The framing here describes the formalist shift
+> descriptively; for the critical reading that Szarkowski's program
+> enabled a depoliticized, formalist canon at the expense of *Family
+> of Man*-style social address, see Sekula 1981 (`src-sekula-1981`,
+> in repo) and Christopher Phillips, 'The Judgment Seat of
+> Photography,' *October* 22 (Autumn 1982): 27–63."
+
+The 2018-and-later post-Phillips counter-readings (e.g., Sarah
+Greenough's edited Szarkowski volumes, Diarmuid Costello's revisionist
+formalism work) are not in this repo and are not paraphrased here.
+The point this essay can responsibly make: the 1964–1966 *Photographer's
+Eye* is the first of two consecutive Szarkowski curatorial gestures
+in the 1960s that re-cast MoMA's photography program away from the
+*Family of Man* model. What that "away" amounts to is contested.
+
+### 3.2 *The Photographer's Eye* book (1966)
+
+The 1966 MoMA book version of the exhibition (ISBN 0-87070-527-X) is
+still in print as of 2026 (per the MoMA Design Store record
+referenced in `src-szarkowski-1966-photographers-eye-book`). The book
+is a Tier-2 critical-scholarly text in `CREDIBILITY.md`'s rubric — a
+named-curatorial-author MoMA publication that has functioned as a
+foundational text for post-1960 photography criticism and curatorial
+practice. The interior text has not been read in this project; the
+five-category framework above is repeated from
+`src-szarkowski-1964-photographers-eye-exh` and not re-quoted from a
+primary source.
+
+### 3.3 *New Documents* (1967)
+
+Szarkowski's second major exhibition opened 28 February 1967 and
+closed 7 May 1967 [src-szarkowski-1967-new-documents]. The
+exhibition presented Diane Arbus (32 photographs), Lee Friedlander
+(30 photographs), and Garry Winogrand (32 photographs) — 94 total
+black-and-white 35mm photographs — at MoMA, and subsequently
+travelled to 14 additional institutions including Goucher College,
+McMaster University, Cornell University, and the San Francisco
+Museum of Art. No catalog was produced at the time of exhibition; a
+50th-anniversary catalog (Sarah Hermanson Meister, ed., *Arbus
+Friedlander Winogrand: New Documents, 1967*, MoMA, 2017, ISBN
+978-0-87070-955-5) was published in 2017.
+
+Szarkowski's curatorial statement is recorded in `src-szarkowski-1967-new-documents`
+verbatim from Wikipedia (which cites Gefter, *NYT*,
+9 July 2007 and Mora, *The Last Photographic Heroes*, Abrams, 2007;
+neither was re-fetched in this round):
+
+> "In the past decade a new generation of photographers has directed
+> the documentary approach toward more personal ends. Their aim has
+> been not to reform life, but to know it."
+
+> "What unites these three photographers is not style or
+> sensibility; each has a distinct and personal sense of the use of
+> photography and the meanings of the world. What is held in common
+> is the belief that the world is worth looking at, and the courage
+> to look at it without theorizing."
+
+The "not to reform life, but to know it" formulation is the cleanest
+single-sentence statement of the post-FoM curatorial pivot. *The
+Family of Man* (1955) had used documentary photography as material
+for a humanist-universalist argument about the human condition; *New
+Documents* (1967) explicitly de-coupled documentary photography from
+reformist or rhetorical aims. In Szarkowski's framing the
+documentary photograph becomes a way of "knowing" the world rather
+than a tool of social-emotional or political address. Whether one
+treats this re-framing as a clarification of the medium's actual
+properties (the descriptive reading) or as a depoliticisation of a
+politically-engaged tradition (the *October*-axis reading) is the
+contested question. The in-repo perspective note above
+[src-szarkowski-1967-new-documents] flags the contestation
+explicitly.
+
+A quoted-source caveat: the Szarkowski quotes above are taken
+verbatim from Wikipedia's article on *New Documents* (fetched
+2026-04-30), which itself cites secondary sources (Gefter 2007;
+Mora 2007). Those secondary sources have not been re-fetched in this
+round. Promotion of the quotes to a directly-fetched primary source
+(MoMA archive; the 2017 anniversary catalog) is an open follow-up.
+
+### 3.4 The 1964 photography galleries
+
+Adjacent to *The Photographer's Eye*, MoMA opened its first
+dedicated photography galleries in 1964 — the **Edward Steichen
+Photography Center** [src-moma-1964-photography-galleries]. Grace M.
+Mayer organised the inaugural exhibition. A rotating selection of
+approximately 200 photographs from MoMA's collection was
+continuously on view. The gallery's naming after Steichen — coupled
+with the simultaneous launch of Szarkowski's formalist program in
+*The Photographer's Eye* — is the institutional marker that
+photography had achieved permanent fine-art-medium status at MoMA.
+The gallery honours the outgoing director while the program inside
+it pivots away from his curatorial idiom. The Mayer-as-organiser
+claim is from the Wikipedia article on Grace M. Mayer (fetched
+2026-04-30) and has not been re-verified against MoMA primary
+records this round.
+
+## 4. Steichen's autobiography (1963) and its reception
+
+*A Life in Photography* (Doubleday in collaboration with the Museum
+of Modern Art, Garden City, N.Y., 1963; 294 pp.) is Steichen's
+own retrospective account, published the year following his
+retirement [src-steichen-1963-life]. The 1984 Bonanza Books reprint
+(ISBN 0517468050) is page-for-page identical to the 1963 first
+edition. The book's interior is access-restricted on Internet
+Archive (`lifeinphotograph0000stei`) and was not read in any session
+of this project so far; bibliographic metadata is confirmed via the
+archive.org item record (fetched 2026-04-29).
+
+The book is the primary first-person source for Steichen's account
+of *The Family of Man*'s concept and selection process, the world
+tour, the USIA partnership, and his self-positioning relative to
+critics. As such it is *also* the primary first-person rejoinder to
+Barthes 1957 (Barthes's "La grande famille des hommes" appeared in
+the 1957 Seuil *Mythologies*; the English translation history was
+not re-verified in this round). The repo notes flag this directly
+[verbatim from `src-steichen-1963-life`, "Notes" section]:
+
+> "This book is the primary rejoinder to Barthes's critique —
+> Steichen's own framing of the exhibition's aims."
+
+Whether the 1963 autobiography actually engages Barthes (as opposed
+to being merely a parallel statement of the curator's position) is
+not determinable without reading the body text. That text is not
+read in this round; the claim above is registered but not
+verified.
+
+The contemporary US press reception of the autobiography is
+documented in this repo only at placeholder level. The expected
+*New York Times* review (1963) is recorded as
+`src-nyt-1963-life-review` with no body text accessed (NYT
+TimesMachine and ProQuest were not consulted in this round). Reviews
+in *Saturday Review*, *Time*, *Newsweek*, and *New York Herald
+Tribune* are listed as open questions in the source file. This is a
+documented gap. As of this round, the 1963 reception of Steichen's
+autobiography exists in the project as a known absence — a placeholder
+that future passes should populate against TimesMachine, ProQuest,
+or library archive scans.
+
+A late-decade *Aperture* treatment of Steichen appeared as
+"Edward Steichen" in *Aperture* (Fall 1969)
+[src-aperture-1969-steichen]. The article URL
+(issues.aperture.org/article/1969/1/1/edward-steichen) returned HTTP
+403 in the 2026-04-30 round and the volume/issue number, author, and
+interior text are unknown. The article is flagged `verified: false`
+on those grounds. It is recorded here as the closing 1960s
+*Aperture*-axis engagement with Steichen (he was approximately 89–90
+at the time; he would die in March 1973).
+
+## 5. Sandburg's death (1967) and the prologue's afterlife
+
+Carl Sandburg died on 22 July 1967 in Flat Rock, North Carolina
+[src-wikipedia-sandburg-1967-death-pointer; verbatim from the
+Wikipedia article re-fetched 2026-05-02 — the file records "died of
+natural causes in 1967 and his body was cremated. Date: 22 July
+1967, in Flat Rock, North Carolina"]. Sandburg's relevance to
+*The Family of Man* runs on two distinct lines:
+
+- **Curatorial-textual.** Sandburg wrote the **prologue** for the
+  1955 exhibition catalog. The Wikipedia bibliography records the
+  contribution as "introduction; images compiled by Edward
+  Steichen"; the MoMA primary record (`src-moma-1955-press-release-book`,
+  in repo from prior rounds) describes the contribution as the
+  **prologue** distributed in full as a leaflet at the opening, and
+  `src-moma-1955-catalog` reproduces it. The MoMA primary terminology
+  is the authoritative one. Sandburg's prologue is one of the
+  exhibition's two attached texts (the other being Steichen's own
+  introduction).
+- **Biographical.** Sandburg had married Lilian Steichen
+  (1883–1977), Edward Steichen's sister, in 1908 — making him
+  Steichen's brother-in-law for nearly six decades [verbatim from
+  `src-wikipedia-sandburg-1967-death-pointer`].
+
+Sandburg's 1967 death is structurally analogous to the 1962 retirement
+in that it removes one of the two named voices from the original
+1955 catalog while the exhibition itself continues to circulate
+(Copy 3 had just been donated to Luxembourg; the partial Clervaux
+installation lay seven years in the future). It is a death of an
+exhibition's text-author rather than an exhibition's curator, but
+both deaths fall in the same five-year band (1962 retirement
+announcement; 1967 Sandburg death; 1973 Steichen death) that
+brackets the original 1955 production team's institutional exit.
+The longer reception arc treats these dates as bookends of the
+exhibition's "first life" — after which the show continues, but
+without its original authors.
+
+The repo currently anchors the 1967 date and the family relation to
+Wikipedia as a pointer source [src-wikipedia-sandburg-1967-death-pointer,
+`verified: true` for the verbatim quotes; `tier: 3` for the
+source itself]. Promotion of the death-date and the family-relation
+claim to a Tier 1 / Tier 2 source (the *NYT* obituary; Niven 1997,
+the canonical Steichen biography, which exists as `src-niven-1997`
+in the repo but has not been opened for the Sandburg-relation claim
+in this session) is an open follow-up. Niven's *Steichen: A
+Biography* (1997) was not consulted in this round.
+
+## 6. The Concerned Photographer / ICP founding (1966–1967) — humanist-photography continuation
+
+Coincident with Szarkowski's first programmatic statement at MoMA,
+Cornell Capa was building an institutional vehicle for the
+documentary-humanist tradition outside MoMA. ICP's institutional
+self-record places the founding of the **International Fund for
+Concerned Photography** in 1966 [src-icp-1966-concerned-photography-fund-institutional;
+fetched 2026-05-02; `verified: true`].
+Verbatim from the ICP about-page:
+
+> "Cornell Capa establishes the International Fund for Concerned
+> Photography in the memory of his brother Robert Capa, a war
+> photographer."
+
+The Wikipedia article on Cornell Capa (re-fetched 2026-05-02 and
+recorded at `src-wikipedia-cornell-capa-concerned-photographer-pointer`)
+gives a slightly different chronology, marking 1967 for the launch
+of *The Concerned Photographer* exhibition series:
+
+> "Beginning in 1967, Capa mounted a series of exhibits and books
+> entitled *The Concerned Photographer*. The exhibits led to his
+> establishment in 1974 of the International Center of Photography."
+
+The two dates are not necessarily incompatible (the **Fund** could
+have been founded 1966 and the **first exhibition** mounted 1967),
+but the discrepancy is not resolved in this round; ICP archival
+records have not been consulted. The 1974 ICP founding date is
+consistent across both pointer sources.
+
+The relationship between *Concerned Photographer* (1966/1967) and
+*The Family of Man* (1955) is institutional **continuity** rather
+than rupture. Robert Capa was one of the most-published photographers
+in *The Family of Man* — the figure of "5 plates" with specific plate
+IDs is recorded in `src-icp-1966-concerned-photography-fund-institutional`'s
+"Relevance" section but those plate IDs were not re-verified against
+the project's photo-data CSVs in this round and are carried as a
+secondary characterisation. Robert Capa's death is recorded in
+`src-icp-1966-concerned-photography-fund-institutional` as "May 1954
+in Indochina" with a pointer to `src-nyt-1954-capa-obit` (the *NYT*
+obituary, in repo); that obit file was **not opened in this round**
+and the "May 1954 in Indochina" framing is carried from the ICP
+source file rather than verified directly. Either way, Capa's death
+preceded *The Family of Man*'s January 1955 opening by less than a
+year. Several FoM photographers
+(Robert Capa, Cornell Capa, Werner Bischof, Henri Cartier-Bresson,
+David Seymour, W. Eugene Smith) became foundational figures in the
+*Concerned Photographer* canon. The repo's 1980s perspective note
+(`research/reception-1980s-critical-theory.md` ¶4) explicitly groups
+Cornell Capa / ICP within the humanist-documentary tradition rather
+than as a counter-tradition. This reading is followed here.
+
+A wrinkle worth noting: the ICP about-page **does not mention** FSA,
+*Family of Man*, or Edward Steichen
+[src-icp-1966-concerned-photography-fund-institutional, "Notes"
+section]. The ICP self-narrative is structured around Robert Capa
+and "concerned photography" as a tradition independent of the 1955
+MoMA show, even though Robert Capa's plates appear in *FoM* and the
+Magnum / Concerned Photographer / FoM photographer overlap is
+substantial. The institutional continuity is real but is not
+self-narrated by ICP as continuity-with-Steichen. This is a
+significant fact for any reading that wants to treat
+*Concerned Photographer* as a "humanist successor" to *The Family of
+Man*: the institutions involved did not narrate themselves that way.
+The continuity is a historian's reconstruction, not an
+institutional self-claim.
+
+## 7. Where the 1960s sit relative to the longer reception thread
+
+Three larger threads are settled — or partially settled — in the 1960s
+and feed into the later decades:
+
+**The institutional-continuity thread.** The Luxembourg donation
+(1965) and the Steichen-expressed wish for Clervaux (1964–1966 per
+CNA; 1966 per the project brief) initiate the custodial chapter that
+the 1990s perspective note picks up
+[`research/reception-1990s-clervaux-installation.md`]. The CNA
+institutional-voice caveat applies from this decade forward — see
+that essay's §1 ("Coexistence, not redemption") for the warning that
+custodial framing co-exists with, but does not redeem or supersede,
+the *October*-axis critique developed by Sekula 1981/1986/1995,
+Phillips 1982, Sandeen 1995, Stimson 2006, and Turner 2013.
+
+**The MoMA-internal-supersession thread.** The 1962 succession and
+the 1964–1967 Szarkowski exhibition cycle constitute the institutional
+predicate for Christopher Phillips's "The Judgment Seat of
+Photography" (*October* 22, Autumn 1982) [src-phillips-1982-judgment-seat,
+not re-read this round]. Phillips reads MoMA's photography program
+under Steichen and Szarkowski together as a "judgment seat"
+canonising photography on aestheticist-modernist terms; the 1962–1967
+events documented above are the empirical material on which that
+1982 reading rests. The 1980s perspective note
+[`research/reception-1980s-critical-theory.md` ¶2] flags Phillips's
+reading as "one influential reading, not settled fact." That caveat
+should be read into the 1960s essay as well.
+
+**The humanist-documentary-continuation thread.** The 1966–1967 ICP
+arc is read in the 1980s perspective note as a continuation of the
+*Family of Man* humanist-documentary line outside MoMA. The repo
+follows that reading rather than the alternative reading (in some
+secondary literature) that *Concerned Photographer* is a counter-canon
+to *Family of Man*. Both readings exist in the literature; the
+project picks the continuity reading explicitly.
+
+**What the 1960s do *not* settle:** the verdict question. There is
+no 1960s monograph in this repo that engages *The Family of Man*
+critically. Barthes 1957 is in French and would not be widely read
+in English until Howard's 1972 translation. Sontag's *On Photography*
+is 1977. Sekula's *Art Journal* essay is 1981. Phillips's *October*
+essay is 1982. The 1960s are pre-critical for *The Family of Man* in
+the sense that the canonical Anglophone critique has not yet been
+written. The decade's published voices on the show are the curator's
+own (Steichen 1963, body text not read; *Aperture* 1969, body text
+not read), Sandburg's death-and-prologue continuity (Sandburg himself
+did not write critically on the exhibition; he was its in-house
+prologue author), and the institutional voices (MoMA press archive,
+USIA, CNA) that handle the show's transitions and afterlife.
+
+## 8. What this essay does not claim
+
+Per the museum-grade-accuracy rule (`CLAUDE.md`), this essay does
+**not** quote verbatim from Steichen's *A Life in Photography*
+(body text inaccessible in this round), the 1969 *Aperture* article
+on Steichen (HTTP 403), Szarkowski's *The Photographer's Eye* book
+interior (not read), the 2017 *New Documents* anniversary catalog
+(not read), Niven 1997 (not consulted in this round for the Sandburg
+relation), or any *NYT* / *Saturday Review* / *Time* / *Newsweek* /
+*New York Herald Tribune* 1963 review of Steichen's autobiography
+(NYT TimesMachine and ProQuest not consulted). The Szarkowski
+*New Documents* quotes are taken from Wikipedia (which cites
+Gefter 2007 and Mora 2007 as secondary sources, neither re-fetched
+this round). The Steichen retirement / succession claims are taken
+from Wikipedia as a pointer source (the underlying MoMA press
+release was fetched as a binary PDF in 2026-04-30 and the interior
+text was not extractable).
+
+The Phillips 1982, Sekula 1981/1986, and Sandeen 1995 framings
+referenced above are *not* paraphrased from those texts in this
+essay; they are referenced by way of cross-reference to the
+in-repo source files and prior decade essays, where the same caveats
+apply.
+
+Specific page numbers from any 1960s-era book are not cited because
+no body text was opened in this round.
+
+## 9. Highest-priority open follow-ups
+
+- A controlled-digital-lending borrow of *A Life in Photography*
+  (Doubleday/MoMA, 1963) — `lifeinphotograph0000stei` on IA — to
+  read Steichen's own 1963 framing of *The Family of Man*'s aims and
+  any rejoinder to Barthes.
+- TimesMachine / ProQuest fetch of the 1963 *NYT* review of
+  Steichen's autobiography, plus *Saturday Review*, *Time*,
+  *Newsweek*, and *New York Herald Tribune* coverage. These are
+  registered as a placeholder in `src-nyt-1963-life-review` and
+  itemised as open questions in that file.
+- Direct fetch of the *Aperture* Fall 1969 article on Steichen
+  (issues.aperture.org/article/1969/1/1/edward-steichen returned
+  403; archive.aperture.org returned 403) via library access to a
+  physical *Aperture* 1969 volume.
+- NARA RG 306 (USIA records) for the diplomatic correspondence
+  surrounding the 1965 Copy-3 transfer to Luxembourg and the
+  1962/1963 dispersals of Copies 1, 2, and 4.
+- *Tageblatt* and *Luxemburger Wort* archives at the Bibliothèque
+  nationale de Luxembourg for press coverage of Steichen's
+  Luxembourg visit and the Copy-3 transfer.
+- Niven 1997 (`src-niven-1997` in repo; not opened this round) for
+  the Sandburg-Steichen family relation, the Sandburg prologue
+  composition, and the Sandburg-and-FoM after-1955 reception.
+- *NYT* obituary for Sandburg (22 July 1967) to anchor the death
+  date and FoM-prologue framing at Tier 1/2.
+- MoMA Press Archive 1962 succession press release
+  (MOMA_1962_0102_99) and the 1964 reopening / Steichen Photography
+  Center inauguration press release — both fetched as binary PDFs
+  in 2026-04-30 and not text-extracted; OCR or library transcript
+  required.
+- *The Photographer's Eye* book (1966, ISBN 0-87070-527-X) — body
+  text reading for the five-category framework, in order to compare
+  Szarkowski's stated curatorial premise against the
+  *October*-axis 1982 reading.
+- The 2017 *New Documents* anniversary catalog (Meister, ed., MoMA,
+  ISBN 978-0-87070-955-5) for the Szarkowski curatorial-statement
+  text in archival reproduction.
+
+## Cross-reference
+
+This essay pairs with:
+
+- `research/reception-1950s-us-press.md` — verification-status
+  framing of the 1950s US-press slice.
+- `research/reception-1970s-critical-theory.md` — the Anglophone
+  critical-theory turn that follows the 1960s.
+- `research/reception-1980s-critical-theory.md` — the *October*-axis
+  consolidation that reads back into the 1962–1967 Szarkowski
+  events.
+- `research/reception-1990s-clervaux-installation.md` — the Clervaux
+  inauguration (1994), Sandeen 1995, and the custodial chapter that
+  the 1965 Luxembourg donation initiates.
+- `research/reception-2000s-stimson-era.md` — fiftieth-anniversary
+  cluster and 2003 UNESCO inscription.
+- `research/reception-2010s-turner-era.md` — Turner's *Democratic
+  Surround* (2013) and the global-reception turn.
+- `research/world-tour.md` — the USIA tour record into which the
+  1962–1965 wind-down events fit.
+- `research/clervaux.md` — custodial history at the CNA.
+
+## Citation provenance summary
+
+All bibliographic claims rest on (i) the 19 in-repo source files
+listed in the YAML frontmatter, all of which were read directly in
+this round; (ii) the verbatim quotes recorded in those files at
+their stated fetch dates (predominantly 2026-04-29, 2026-04-30, and
+2026-05-02). No external WebFetch or curl call was made in this
+round; the worktree-isolation tool layer denies WebFetch (per the
+2026-05-09 smoke test recorded in `CLAUDE.md`). All decade-level
+claims about Barthes, Sontag, Sekula, Phillips, Sandeen, Stimson,
+and Turner are by reference to the cross-referenced decade essays
+and not by paraphrase of those critics' own texts; their texts were
+not re-read in this round.
+
+The Wikipedia pointer sources (Sandburg 1967 death; Steichen 1962
+retirement; Cornell Capa 1967 *Concerned Photographer*; *Family of
+Man* USIA copies dispersal) carry `verified: true` for the verbatim
+quotes recorded in their respective files and `tier: 3` for the
+source itself; per `CREDIBILITY.md` they are pointer sources to be
+promoted to Tier 1/2 against archival or canonical biography records
+in a future round.

--- a/research/reception-1960s-szarkowski-transition.md
+++ b/research/reception-1960s-szarkowski-transition.md
@@ -576,7 +576,8 @@ project picks the continuity reading explicitly.
 **What the 1960s do *not* settle:** the verdict question. There is
 no 1960s monograph in this repo that engages *The Family of Man*
 critically. Barthes 1957 is in French and would not be widely read
-in English until Howard's 1972 translation. Sontag's *On Photography*
+in English until Annette Lavers's 1972 translation (Hill and Wang;
+translator named per `src-barthes-1957`). Sontag's *On Photography*
 is 1977. Sekula's *Art Journal* essay is 1981. Phillips's *October*
 essay is 1982. The 1960s are pre-critical for *The Family of Man* in
 the sense that the canonical Anglophone critique has not yet been


### PR DESCRIPTION
## Summary

Adds `research/reception-1960s-szarkowski-transition.md` (698 lines) to close the 1960s gap in the decade-by-decade reception thread. The thread now covers 1950s (US-press slice), 1960s (this PR), 1970s, 1980s, 1990s, 2000s, and 2010s — six explicit reception essays plus the 1950s perspective note.

Closes #154.

## Scope

- **Steichen retirement 1961–1962**: 28 March – 30 May 1961 *Steichen the Photographer* solo show; 18 October – 25 November 1962 *Bitter Years* with Steichen as Director Emeritus.
- **Szarkowski appointment**: effective 1 July 1962, succeeding Steichen at MoMA's Department of Photography.
- **USIA tour wind-down 1962–1965**: four-copy dispersal table; Copy 3 to Luxembourg in 1965.
- **Luxembourg donation 1965** + Steichen's Clervaux preference (CNA bracket: 1964–1966).
- **Szarkowski's curatorial program**: *The Photographer's Eye* (1964 exhibition / 1966 book; ISBN 0-87070-527-X) and *New Documents* (1967; Arbus / Friedlander / Winogrand) as the pivot away from FoM-style humanist exhibition-making.
- **Sandburg's death 22 July 1967** in Flat Rock, NC, and the prologue's afterlife.
- **Concerned Photographer / ICP Fund founding 1966** (per ICP about-page; Wikipedia gives 1967 for the exhibition-series launch) as the humanist-documentary continuation outside MoMA.
- **Steichen's 1963 autobiography** *A Life in Photography* reception — placeholder-only in repo, NYT/Saturday Review/Time/Newsweek/Herald Tribune coverage flagged as open follow-up.
- **1969 *Aperture* article on Steichen** — recorded as 403'd in prior round; body unread.

## Sourcing posture

19 in-repo source files cited, all read directly in this session at `sources/1960s/`. **No external WebFetch or curl call was performed in this round** — the worktree-isolation tool layer denies WebFetch per the 2026-05-09 smoke test recorded in `CLAUDE.md`.

All decade-level references to Barthes, Sontag, Sekula, Phillips, Sandeen, Stimson, and Turner are by **cross-reference** to existing decade essays — never by paraphrase of those critics' own texts (which were not re-read in this round).

## Anti-confabulation audit

CoVe self-audit caught three confabulation candidates pre-commit and fixed them:

1. Sandburg "age 89" claim — removed (not present in `src-wikipedia-sandburg-1967-death-pointer`).
2. Robert Capa "5 plates: photo-0023…" specific plate IDs — hedged as carried-claim from `src-icp-1966-concerned-photography-fund-institutional` rather than re-verified against the photo data CSVs this round.
3. Howard 1972 English *Mythologies* translation date — hedged (not verified in this round; original-French 1957 *Mythologies* date retained).

## Validators

- `python3 scripts/validate_schema.py` — OK
- `python3 scripts/check_credibility.py` — OK (206/140)
- `python3 scripts/check_injection_patterns.py` — no markers matched

## Test plan

- [ ] Verify the essay renders correctly in any tooling that parses YAML frontmatter.
- [ ] Cross-decade hand-off: confirm references to `research/reception-1970s-critical-theory.md` § *Coexistence, not supersession* and `research/reception-1980s-critical-theory.md` ¶4 (Cornell Capa / ICP grouped within humanist-documentary tradition) match the actual text in those files.
- [ ] Future round: open Steichen 1963 *A Life in Photography* via IA CDL borrow; promote `src-nyt-1963-life-review` from placeholder to full record via TimesMachine/ProQuest; open Niven 1997 for the Sandburg-relation claim and Sandburg-prologue composition history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)