### PR TITLE
Photo-stories batch 06: +5 photographs (Sander × 2, Hamaya, Yamahata, Feininger)

### DIFF
--- a/research/photographs/photo-0263.md
+++ b/research/photographs/photo-0263.md
@@ -1,0 +1,60 @@
+# Photograph: photo-0263
+
+| Field | Value |
+|---|---|
+| ID | photo-0263 |
+| Title | Untitled (no title in the 1955 checklist) |
+| Photographer | Hiroshi Hamaya (1915–1999), Japanese (see `data/photographers.csv`) |
+| Year | (not recorded in checklist; photograph mid-1950s per contextual sources — not independently verified at plate level) |
+| Country of origin | Japan |
+| Section | sec-relationships-community (Section 24, Ring Around the Rosy — approximate cluster mapping) |
+| MoMA object ID | (not filled — MoMA collection page not fetched this round) |
+| On display at Clervaux | unknown |
+| Sources | `src-moma-exh-0569-master-checklist`, `src-icp-hiroshi-hamaya`, `src-wikipedia-hamaya-pointer`, `src-takenaka-2020-popular-inquiry-japan` |
+
+## Provenance
+
+The MoMA Master Checklist (`src-moma-exh-0569-master-checklist`, Tier-1, in-repo, fetched 2026-04-19) records plate #274 as:
+
+> *"Japan — Hiroshi Hamaya, Japanese — 18 × 12"*
+
+This is the only Hamaya plate in *The Family of Man*, per strict-match grep against `data/photographs.csv` (verified 2026-05-10). The checklist credits Hamaya directly under his own name with no intermediary agency or publication — unusual in a catalog where many photographers appear under a Magnum or LIFE credit. This suggests the print reached MoMA through a direct submission or via a curatorial contact within Japan, rather than through a wire-service or agency route. The precise submission pathway is not documented in any source fetched this round.
+
+The checklist does not record a title or date for this plate. Plate #274 falls within Section 24 "Ring Around the Rosy" — the exhibition's section devoted to children at play.
+
+The ICP archive page (`src-icp-hiroshi-hamaya`, Tier-1, in-repo, fetched 2026-05-10, saved at `.scratch/icp-hiroshi-hamaya-2026-05-10.html`) records Hamaya's life dates as "1915 - 1999" and birth in Tokyo. Hamaya did not join Magnum until 1960 (verbatim: "A member since 1960 of Magnum"), so at the time of *The Family of Man* he was an independent freelance photographer.
+
+Wikipedia (`src-wikipedia-hamaya-pointer`, Tier-3, pointer-only, in-repo, fetched 2026-05-10) records the subject of this plate verbatim as: "By 1955 one of Hiroshi Hamaya's photographs, a high-angle view of kimono-clad springtime dancers led by his wife, was included by curator Edward Steichen in the world-touring Museum of Modern Art exhibition *The Family of Man*." This subject identification — "a high-angle view of kimono-clad springtime dancers led by his wife" — is consistent with checklist #274's placement in Section 24 Ring Around the Rosy. This identification carries pointer status only and should not be promoted to a print-record claim without a fetched MoMA installation photograph or original print attribution.
+
+The current physical location of the print — whether it is among the Clervaux Castle holdings (CNA, Luxembourg) — was not verified this round. The CNA Steichen Collections site was not fetched this session.
+
+## Subject and context
+
+Per the MoMA Master Checklist, plate #274 is set in Japan and appears in Section 24 "Ring Around the Rosy." The checklist does not describe the subject.
+
+The Wikipedia article (`src-wikipedia-hamaya-pointer`, Tier-3, pointer-only, fetched 2026-05-10) identifies the subject as "a high-angle view of kimono-clad springtime dancers led by his wife." If this identification is accurate, the photograph depicts a traditional Japanese dance or festival procession photographed from above — a compositional strategy Hamaya developed during his intensive fieldwork in rural Japan in the mid-1950s. The ICP biography records that Hamaya's "mid-1950s studies of the people of Japan's rural areas, where folk customs remained strong," produced two major photobook series: *Yuki Guni* (The Snow Country, 1956) and *Ura Nihon* (Back Regions of Japan) — verbatim from `src-icp-hiroshi-hamaya`, fetched 2026-05-10. This contextual background is consistent with a springtime festival photograph; whether plate #274 was taken during fieldwork for either of those projects is not confirmed in any source fetched this round.
+
+Section 24 "Ring Around the Rosy" in the exhibition is a cluster of photographs of children at play, grouped under the name of the traditional circular game. The 18 × 12 cm dimensions are consistent with a vertical-format photograph. Within the section, plate #274 (Japan) sits in an international sequence that spans Romania (plate #283, Werner Bischof), Israel (plate #274's neighbors include plate #274 itself and adjacent plates at #270 through #287 per the checklist's Section 24 range). The precise installation neighbors are documented in `data/photographs.csv` for adjacent photo IDs.
+
+Hamaya photographed during a period of intensive engagement with Japanese rural and seasonal life. The ICP biography (verbatim, fetched 2026-05-10) describes the development of his theory of "Fudo, a term describing an individual's conception of and attitude toward his or her general environment, including its topography, flora and fauna, climate, and ecology" — suggesting that his photographs of Japanese folk customs were part of a deeper philosophical engagement with environment and community rather than straightforward documentary reportage.
+
+## Reception / analysis
+
+No plate-specific critical reception for checklist #274 has been located in any source consulted this round.
+
+Takenaka (2020, `src-takenaka-2020-popular-inquiry-japan`, Tier-2, in-repo, fetched 2026-05-09) documents that the Japan tour of *The Family of Man* (March 1956 through 1957) attracted over one million visitors and included Japanese-produced versions of the exhibition. Hamaya is not named as a member of the Japanese executive committee for the tour (the committee photographers named in Takenaka p. 46 are Ihee Kimura, Yoshio Watanabe, Shigene Kanemaru, and Yasuhiro Ishimoto); his role was as a contributing photographer to the New York exhibition rather than as a tour organizer.
+
+Roland Barthes, in "The Great Family of Man" (`src-barthes-1957`, Tier-2, in-repo, fetched 2026-04-19), does not name Hamaya or any Japanese plate. Barthes's observation that the exhibition presented cultural difference as surface exoticism — "the difference between human morphologies is asserted, exoticism is insistently stressed" before being resolved into a universal "family" — is relevant to the exhibition's framing of Japanese folk-dance imagery.
+
+## Perspective notes
+
+- **Curatorial (MoMA 1955):** The placement of a Japanese photograph in Section 24 Ring Around the Rosy — a section named for a Western children's game — frames Japanese springtime dance through the lens of a universalized concept of children's play and circular, communal movement. Steichen's title removal further depersonalizes the image's specific cultural context.
+- **Japanese reception:** Takenaka (2020) documents that the Japan tour made *The Family of Man* the most influential American exhibition in the history of Japanese photography ("the most influential exhibition of the U.S. in the history of Japanese photography," verbatim from `src-takenaka-2020-popular-inquiry-japan` p. 45). The presence of a Hamaya plate in the New York exhibition — before Hamaya's mid-career transformation into Japan's foremost nature photographer — represents an early international recognition of his work.
+
+## Open questions
+
+- The subject identification ("kimono-clad springtime dancers led by his wife") is pointer-only from Wikipedia and has not been independently confirmed from any Tier-1/2 source fetched this round.
+- The specific date and location of the photograph within Japan are not recorded in the checklist and have not been confirmed.
+- Whether the print currently forms part of the Clervaux Castle holdings (CNA, Luxembourg) was not verified this round.
+- Whether plate #274 corresponds to a known MoMA object ID was not verified this round.
+- Hamaya joined Magnum in 1960 as its first Japanese member; whether that affiliation prompted later retrospective attention to his 1955 FoM plate is not documented in any source fetched this round.

--- a/research/photographs/photo-0316.md
+++ b/research/photographs/photo-0316.md
@@ -1,0 +1,61 @@
+# Photograph: photo-0316
+
+| Field | Value |
+|---|---|
+| ID | photo-0316 |
+| Title | Untitled (no title in the 1955 checklist) |
+| Photographer | Andreas Feininger (1906–1999), American (see `data/photographers.csv`) |
+| Year | (not recorded in checklist; not filled) |
+| Country of origin | USA |
+| Section | sec-relationships-community (Section 25, Relationships) |
+| MoMA object ID | (not filled — MoMA collection page not fetched this round) |
+| On display at Clervaux | unknown |
+| Sources | `src-moma-exh-0569-master-checklist`, `src-icp-andreas-feininger-archive`, `src-britannica-andreas-feininger`, `src-wikipedia-andreas-feininger-pointer` |
+
+## Provenance
+
+The MoMA Master Checklist (`src-moma-exh-0569-master-checklist`, Tier-1, in-repo, fetched 2026-04-19) records plate #327 as:
+
+> *"U.S.A. — Andreas Feininger, LIFE, American — 140 × 102"*
+
+This is the first of two Feininger plates in *The Family of Man*, per strict-match grep against `data/photographs.csv` (verified 2026-05-09). The two plates are: photo-0316 (#327, Section 25 Relationships, USA, LIFE, 140 × 102 cm) and photo-0332 (#344, Section 26 Learning, USA, LIFE, 20 × 20 cm). Both are credited as LIFE / American.
+
+At 140 × 102 cm, plate #327 is among the largest prints in this portion of the checklist and one of the larger prints in the exhibition overall (cf. the Feininger plate at #327, Bischof at #395 [16 × 23 3/4], Kessel at #12 [140 × 144], Sanders at #225 [140 × 108]). Plate #327 is the final numbered plate of Section 25 "Relationships."
+
+The ICP archive page (`src-icp-andreas-feininger-archive`, Tier-1, in-repo, fetched 2026-05-09 and re-confirmed live via WebFetch 2026-05-10, saved at `.scratch/icp-andreas-feininger-2026-05-10.html`) records Feininger's life dates as "1906 - 1999." The Britannica entry (`src-britannica-andreas-feininger`, Tier-3, in-repo, fetched 2026-05-09) gives verbatim: "born December 27, 1906, Paris, France" and "died February 18, 1999, New York, New York, U.S. (aged 92)."
+
+The checklist does not record a title or date for this plate. Whether the print is currently held in the Clervaux Castle collection (CNA, Luxembourg) or the MoMA permanent collection was not verified this round.
+
+## Subject and context
+
+Per the MoMA Master Checklist, plate #327 is set in the USA, credited to LIFE, and appears in Section 25 "Relationships." The checklist does not describe the subject.
+
+Andreas Feininger (1906–1999) was a LIFE staff photographer from 1943 to 1962 (verbatim from ICP biography, fetched 2026-05-09 and re-confirmed 2026-05-10: "a staff photographer at [LIFE] from 1943 to 1962, and there established his reputation"). He was born in Paris as the son of the Bauhaus painter Lyonel Feininger, educated at the Weimar Bauhaus, and emigrated to the USA via Stockholm in 1939 (verbatim from ICP biography: "Feininger was a pioneer both visually and technically. Born in Paris, son of the painter Lyonel Feininger, Andreas was educated in German public schools and at the Weimar Bauhaus").
+
+Feininger's photographic practice at LIFE during the 1940s and 1950s encompassed New York City cityscapes and architectural subjects, as well as nature photography. The ICP biography describes his artistic orientation as documenting "the unity of natural things, their interdependence, and their similarity to constructed forms" (verbatim from ICP biography, re-confirmed 2026-05-10). This philosophical perspective — finding structural resemblance across human, built, and natural forms — makes Feininger a representative of the kind of visual universalism that the exhibition itself promotes.
+
+The large format (140 × 102 cm) of plate #327 suggests this was a prominent installation piece — a wall-scale image that would have dominated its corner of Section 25. Its position as the final numbered plate of Section 25 "Relationships" places it at the transition to Section 26 "Learning." The specific subject of the photograph — whether it depicts a human relationship, a cityscape, or another subject that thematically fits "Relationships" — is not stated in the checklist and has not been confirmed from any Tier-1/2 source fetched this round.
+
+Section 25 "Relationships" sits within the `sec-relationships-community` cluster per `data/sections.csv` (in-repo, read this session), which spans Section 18 Adult Play through Section 25 Relationships.
+
+## Reception / analysis
+
+No plate-specific critical reception for checklist #327 has been located in any source consulted this round.
+
+The ICP biography (verbatim, fetched 2026-05-09 and re-confirmed 2026-05-10) states that "Feininger was renowned as a teacher via his publications that combine practical experience with clarity of presentation." The photographic archive of Andreas Feininger is housed at the Center for Creative Photography, Tucson (verbatim from ICP biography, re-confirmed 2026-05-10). This archive location is noted as a potential resource for identifying plate #327 among Feininger's known works.
+
+Roland Barthes, in "The Great Family of Man" (`src-barthes-1957`, Tier-2, in-repo, fetched 2026-04-19), does not name Feininger or any LIFE photographer by name. The exhibition's recruitment of major LIFE photographers — and LIFE's own publication of a photographic essay on *The Family of Man* in January 1955 — represents the intersection of humanist documentary practice and mass-market photojournalism that Barthes's critique targets.
+
+The Britannica entry (`src-britannica-andreas-feininger`, Tier-3, in-repo, fetched 2026-05-09) notes that Feininger was "noted for his dynamic black-and-white scenes of [cityscapes] and nature," and frames his career as that of "an American photographer and writer on photographic technique." Neither Britannica nor Wikipedia mentions *The Family of Man* on Feininger's biography page (verified by string-search 2026-05-09); the connection to FoM is anchored at the plate level only, via the MoMA Master Checklist.
+
+## Perspective notes
+
+- **Curatorial (MoMA 1955):** The large-format installation of plate #327 as Section 25's final image suggests it was intended as a visual anchor — a statement image to close that section. Feininger's LIFE credential (the most commercially powerful photographic institution in mid-century America) is explicitly recorded in the checklist. This is the exhibition presenting the aesthetic of American photojournalism at wall scale.
+- **Critical:** Feininger's background — European-born, Bauhaus-trained, emigrated to the USA — makes him a figure in the broader mid-century transatlantic visual culture that *The Family of Man* both embodied and promoted. His Bauhaus education (formal rigor, attention to form) alongside his LIFE practice (documentary accessibility, emotional engagement) positions him at the intersection of the exhibition's dual aesthetic registers.
+
+## Open questions
+
+- The specific subject of plate #327 — what it depicts — is not stated in the checklist and has not been confirmed from any Tier-1/2 source fetched this round. The Center for Creative Photography archive in Tucson is the recommended search location for identifying this image among Feininger's extant prints.
+- Whether the print currently forms part of the Clervaux Castle holdings (CNA, Luxembourg) was not verified this round.
+- Whether plate #327 corresponds to a known MoMA object ID was not verified this round.
+- The specific year and circumstances of the photograph are unknown without a successful identification of the image.

--- a/research/photographs/photo-0402.md
+++ b/research/photographs/photo-0402.md
@@ -1,0 +1,57 @@
+# Photograph: photo-0402
+
+| Field | Value |
+|---|---|
+| ID | photo-0402 |
+| Title | Untitled (no title in the 1955 checklist) |
+| Photographer | August Sander (1876–1964), German (see `data/photographers.csv`) |
+| Year | (not recorded in checklist; not filled) |
+| Country of origin | Germany |
+| Section | sec-play-learning (Section 35, Teens) |
+| MoMA object ID | (not filled — MoMA collection page not fetched this round) |
+| On display at Clervaux | unknown |
+| Sources | `src-moma-exh-0569-master-checklist`, `src-icp-august-sander-archive`, `src-sfmoma-august-sander`, `src-wikipedia-august-sander-pointer` |
+
+## Provenance
+
+The MoMA Master Checklist (`src-moma-exh-0569-master-checklist`, Tier-1, in-repo, fetched 2026-04-19) records plate #415 as:
+
+> *"Germany — August Sander, German — 28 × 19 1/2"*
+
+This is the second of three Sander plates in *The Family of Man*, per strict-match grep against `data/photographs.csv` (verified 2026-05-09). The three plates are: photo-0146 (#153, Section 15 Work A, Germany, 28 × 21 3/4 cm), photo-0402 (#415, Section 35 Teens, Germany, 28 × 19 1/2 cm), and photo-0447 (#462, Section 41 Couples, Germany, 18 × 12 1/2 cm). All three are set in Germany and credited "German" — fully consistent attribution across all appearances.
+
+The checklist does not record a title, a photograph date, or any agency or publication intermediary. Plate #415 falls within Section 35 "Teens," the checklist's section for adolescent subjects. The 28 × 19 1/2 cm dimensions are slightly smaller than the Work A plate (#153, 28 × 21 3/4 cm) but within the same height register.
+
+The current physical location of the print — whether it is among the Clervaux Castle holdings (CNA, Luxembourg) — was not verified this round. The CNA Steichen Collections site was not fetched this session. The MoMA collection page for Sander's works was not fetched this round.
+
+The ICP archive page (`src-icp-august-sander-archive`, Tier-1, in-repo, fetched 2026-05-09 and re-confirmed live via WebFetch 2026-05-10, saved at `.scratch/icp-august-sander-2026-05-10.html`) records Sander's life dates as "1876 - 1964" and nationality as "German." The SFMOMA collection page (`src-sfmoma-august-sander`, Tier-1, in-repo, fetched 2026-05-09) corroborates "1876, Herdorf, Germany" and "1964, Cologne, Germany."
+
+The Hurm/Reitz/Zamir volume (`src-hurm-reitz-zamir-2018`, Tier-2, in-repo) is noted in its CNA documentation page description as including "a letter by August Sander" among its primary historical documents. That letter's contents were not read in this session; whether it concerns any specific plate or Sander's experience of the exhibition generally is not confirmed from any fetched source.
+
+## Subject and context
+
+Per the MoMA Master Checklist, plate #415 is set in Germany and appears in Section 35 "Teens." The checklist does not describe the subject of the photograph.
+
+August Sander (1876–1964) is best known for his typological portrait project *Menschen des 20. Jahrhunderts* (Citizens of the Twentieth Century), a comprehensive sociological survey of German social types. The ICP archive page (verbatim, fetched 2026-05-09 and re-confirmed 2026-05-10) describes it as "a comprehensive document of the German people entitled 'Menschen des 20. Jahrhunderts' (Citizens of the Twentieth Century). He worked on the project throughout the next two decades, while also producing photographs of architectural and industrial subjects." The project included multiple "portfolios" organized by social type, including a portfolio on young people. Whether plate #415 derives from *Menschen des 20. Jahrhunderts* specifically — and which subject category it might represent — is not stated in the checklist and has not been confirmed from any Tier-1/2 source fetched this round.
+
+The ICP biography also records that Sander was "forced to discontinue 'Citizens of the Twentieth Century'" as Nazi officials became suspicious of his work due to his Communist son, "who died in prison in 1944" (verbatim, ICP archive page, fetched 2026-05-09). His earlier cessation of the project means that the pool of photographs available for inclusion in *The Family of Man* in 1955 was drawn from a career that had been partially interrupted by political circumstances.
+
+Within Section 35 "Teens," Sander's plate is placed in a section devoted to adolescent experience. Steichen's title-deprivation practice — documented in the CNA education portal as Steichen "took the pictures out of their context, deprived them from their title, their date or any mention about their original place" — means any typological classification Sander may have assigned to the subject does not appear in the exhibition's presentation.
+
+## Reception / analysis
+
+No plate-specific critical reception for checklist #415 has been located in any source consulted this round.
+
+Roland Barthes, in "The Great Family of Man" (`src-barthes-1957`, Tier-2, in-repo, fetched 2026-04-19), argues that the exhibition naturalized historically contingent social conditions as universal human experience, placing "Nature at the bottom of History." Barthes's critique is not directed at any individual plate, but at the exhibition's overall framing. The placement of Sander's typological portrait of a young person — a photograph made as part of a systematic sociological survey of German society — within a universal "Teens" section is an apt instance of the displacement Barthes describes: the image's original sociological specificity (German, a particular class or type within Sander's taxonomy) is absorbed into a humanist narrative of universal adolescence.
+
+## Perspective notes
+
+- **Curatorial (MoMA 1955):** Sander's plate in Section 35 functions as Germany's contribution to the exhibition's international panorama of adolescence — one image among many from different countries assembled to suggest the universality of youth. Steichen's title removal stripped away Sander's own typological classification.
+- **Critical:** Sander's systematic, distanced documentary method was oriented toward sociological taxonomy rather than emotional empathy. Within the FoM frame, this distance may read as universalizing rather than analytical — a tension that critical theorists working on photographic archives have noted in the broader literature on Sander, though specific scholarship connecting this plate to that literature has not been confirmed in any Tier-1/2 source fetched this round.
+
+## Open questions
+
+- The specific subject of plate #415 — which figure, age group, or typological category — is not stated in the checklist and has not been confirmed from any Tier-1/2 source in this session.
+- Whether the print currently forms part of the Clervaux Castle holdings (CNA, Luxembourg) was not verified this round.
+- Whether plate #415 corresponds to a known MoMA object ID was not verified this round.
+- The contents of the August Sander letter included in Hurm/Reitz/Zamir 2018 (`src-hurm-reitz-zamir-2018`) were not read in this session.

--- a/research/photographs/photo-0435.md
+++ b/research/photographs/photo-0435.md
@@ -1,0 +1,61 @@
+# Photograph: photo-0435
+
+| Field | Value |
+|---|---|
+| ID | photo-0435 |
+| Title | Untitled (no title in the 1955 checklist) |
+| Photographer | Yosuke Yamahata (1917–1966), Japanese (see `data/photographers.csv`) |
+| Year | (not recorded in checklist; not filled) |
+| Country of origin | Japan |
+| Section | sec-relationships-community (Section 39, Faces — approximate cluster mapping) |
+| MoMA object ID | (not filled — MoMA collection page not fetched this round) |
+| On display at Clervaux | unknown |
+| Sources | `src-moma-exh-0569-master-checklist`, `src-icp-yosuke-yamahata`, `src-wikipedia-yamahata-pointer`, `src-takenaka-2020-popular-inquiry-japan`, `src-obrian-2008-nuclear-family-of-man` |
+
+## Provenance
+
+The MoMA Master Checklist (`src-moma-exh-0569-master-checklist`, Tier-1, in-repo, fetched 2026-04-19) records plate #450 as:
+
+> *"Japan — Yosuke Yamahata, G. T. Sun Company, Japanese — 22 × 17 1/4"*
+
+This is the only Yamahata plate in the original New York 1955 exhibition, per strict-match grep against `data/photographs.csv` (verified 2026-05-10). The checklist credits Yamahata through "G. T. Sun Company" — his Japanese photo agency — making this the first and only "G. T. Sun Company" credit in the catalog.
+
+Plate #450 falls within Section 39 "Faces," a section near the end of the exhibition's main sequence. The 22 × 17 1/4 cm dimensions are a mid-range vertical format, consistent with a close portrait.
+
+The ICP constituent page (`src-icp-yosuke-yamahata`, Tier-1, in-repo, fetched 2026-05-10, saved at `.scratch/icp-yosuke-yamahata-2026-05-10.html`) confirms Yamahata's life dates as "1917 - 1966" and nationality as "Japanese." The page does not carry a long-form biographical paragraph; it lists archival photographs of the Nagasaki aftermath (August 10, 1945) in its collection. The ICP page does not mention *The Family of Man* (verified 2026-05-10 by string-search in the fetched content).
+
+The cluster mapping `sec-relationships-community` for Section 39 Faces is approximate, not canonical (established at photo-0431 per `data/photographs.csv` notes).
+
+**Critical distinction — 1955 NY plate vs. 1956 Tokyo additions:** This entry concerns plate #450, the single Yamahata image in the original New York exhibition. It is NOT one of the five Nagasaki aftermath photographs that were specifically added to the Tokyo tour version. Takenaka (2020, `src-takenaka-2020-popular-inquiry-japan`, p. 47, Tier-2, in-repo) records verbatim: "Steichen and the committee decided to add 60 works by Japanese photographers, among which five of Yosuke Yamahata's aftermath photographs from atomic bombing on Nagasaki were included, in order to make the show special." Those five added photographs are distinct objects from plate #450 of the New York exhibition.
+
+The current physical location of the print — whether it is among the Clervaux Castle holdings (CNA, Luxembourg) — was not verified this round.
+
+## Subject and context
+
+Per the MoMA Master Checklist, plate #450 is set in Japan and appears in Section 39 "Faces." The checklist does not describe the subject of the photograph.
+
+Yamahata (born 6 August 1917 in Singapore under British Straits Settlements administration; died 18 April 1966 in Tokyo — day-month tokens from `src-wikipedia-yamahata-pointer`, Tier-3, pointer-only, in-repo, fetched 2026-05-10; year-only resolution independently confirmed by ICP constituent page) is best known for his Nagasaki documentation. On August 10, 1945, the day after the Nagasaki atomic bombing, Yamahata photographed the city as part of a Japanese army film unit. Those photographs were later published as *Atomized Nagasaki*.
+
+However, the photograph at plate #450 (Section 39 Faces) is credited to "G. T. Sun Company" — Yamahata's civilian photo agency — and appears in a section devoted to portrait faces. This indicates that Yamahata's representation in the New York 1955 exhibition was through a commercial portrait photograph rather than through his Nagasaki documentation. The specific subject of the portrait — who is depicted — is not recorded in the checklist and has not been confirmed from any source fetched this round.
+
+The connection between Steichen and the Yamahata family predates the exhibition. O'Brian (2008, `src-obrian-2008-nuclear-family-of-man`, p. 2, Tier-2, in-repo, fetched 2026-05-09) records verbatim: "In 1952, Steichen visited Japan. A photograph shows him holding a book of photographs by Yamahata Yosuke, *Atomized Nagasaki*, in the presence of the photographer's father" — with the image caption "Yamahata Shogyoku, father of Yamahata Yosuke, with Edward Steichen in Tokyo, 1952." This 1952 Steichen visit to Japan is the earliest documented direct connection between Steichen and the Yamahata family, three years before the New York exhibition opened.
+
+## Reception / analysis
+
+The broader critical and historical reception of Yamahata's relationship to *The Family of Man* focuses predominantly on the Tokyo tour controversy rather than on plate #450. Takenaka (2020, `src-takenaka-2020-popular-inquiry-japan`, Tier-2, in-repo) records verbatim the events of March 23, 1956: "when two days after the opening, the Emperor Showa visited the venue, one wall of one section was concealed with a white curtain to hide the images of victims of atomic bombing on Nagasaki." These censored images were the five Nagasaki photographs added specifically to the Tokyo tour — not plate #450 from the New York exhibition.
+
+O'Brian (2008, `src-obrian-2008-nuclear-family-of-man`, p. 4, Tier-2, in-repo, fetched 2026-05-09) records verbatim: "When the emperor visited *The Family of Man* in Tokyo, Yamahata's photographs were curtained off and then removed altogether from the exhibition." The April 29, 1956 issue of *Asahi Graph* — cited verbatim by Takenaka — ran a photograph of the concealed wall with the headline "Your Highness the Emperor and Prince Yoshi, Please Look at These."
+
+No plate-specific critical reception for checklist #450 (the New York 1955 Faces plate) specifically has been located in any source consulted this round. The scholarly literature on Yamahata and *The Family of Man* focuses on the Tokyo censorship controversy rather than on the identity or reception of the New York 1955 portrait.
+
+## Perspective notes
+
+- **Curatorial (MoMA 1955):** The inclusion of a Yamahata portrait in Section 39 Faces — rather than any of his Nagasaki photographs — suggests that Steichen selected Yamahata's work as a straightforward contribution to the exhibition's international portrait sequence, separate from the atomic-bomb dimension of his biography. The G. T. Sun Company credit indicates the print was sourced through Yamahata's commercial agency. Steichen's 1952 encounter with *Atomized Nagasaki* in Japan (per O'Brian 2008) indicates Steichen was aware of Yamahata's Nagasaki work when making the selection.
+- **Historical / political:** The splitting of Yamahata's representation between a commercial portrait (New York) and five Nagasaki aftermath photographs (Tokyo addition) reflects a careful negotiation of the exhibition's Cold War cultural-diplomacy mandate: the New York exhibition presented Yamahata as a face among faces; the Japanese committee and Steichen together chose to augment that representation with the politically charged Nagasaki images for the Japanese audience, with consequences that became a significant moment in the exhibition's international reception history.
+
+## Open questions
+
+- The specific subject of plate #450 — the face depicted, whether it is a portrait or a crowd image — is not stated in the checklist and has not been confirmed from any Tier-1/2 source fetched this round.
+- Whether the print currently forms part of the Clervaux Castle holdings (CNA, Luxembourg) was not verified this round.
+- Whether plate #450 corresponds to a known MoMA object ID was not verified this round.
+- The nature of G. T. Sun Company — its exact character as an agency or publication, and its other clients or credits in the period — has not been confirmed from any source fetched this round.

--- a/research/photographs/photo-0447.md
+++ b/research/photographs/photo-0447.md
@@ -1,0 +1,59 @@
+# Photograph: photo-0447
+
+| Field | Value |
+|---|---|
+| ID | photo-0447 |
+| Title | Untitled (no title in the 1955 checklist) |
+| Photographer | August Sander (1876–1964), German (see `data/photographers.csv`) |
+| Year | (not recorded in checklist; not filled) |
+| Country of origin | Germany |
+| Section | sec-rededication-future (Section 41, Couples — approximate cluster mapping) |
+| MoMA object ID | (not filled — MoMA collection page not fetched this round) |
+| On display at Clervaux | unknown |
+| Sources | `src-moma-exh-0569-master-checklist`, `src-icp-august-sander-archive`, `src-sfmoma-august-sander`, `src-wikipedia-august-sander-pointer` |
+
+## Provenance
+
+The MoMA Master Checklist (`src-moma-exh-0569-master-checklist`, Tier-1, in-repo, fetched 2026-04-19) records plate #462 as:
+
+> *"Germany — August Sander, German — 18 × 12 1/2"*
+
+This is the third and final Sander plate in *The Family of Man*, per strict-match grep against `data/photographs.csv` (verified 2026-05-09). The three plates are: photo-0146 (#153, Section 15 Work A, Germany, 28 × 21 3/4 cm), photo-0402 (#415, Section 35 Teens, Germany, 28 × 19 1/2 cm), and photo-0447 (#462, Section 41 Couples, Germany, 18 × 12 1/2 cm). All three are set in Germany and credited "German" — fully consistent attribution across all appearances.
+
+The checklist does not record a title, photograph date, or any agency or publication intermediary. Plate #462 falls within Section 41 "Couples," in the exhibition's closing arc, positioned after the H-bomb image (plate #456) and within the renewal sequence that follows it. The 18 × 12 1/2 cm dimensions are smaller than the other two Sander plates — a more intimate-format photograph consistent with the section's subject matter.
+
+The cluster mapping `sec-rededication-future` is approximate, not canonical. The catalog's 11 thematic clusters in `data/sections.csv` have no explicit "couples" cluster, and Section 41 sits in the post-Bomb closing arc. Alternative mappings to `sec-lovers` or `sec-marriage-birth` are defensible; `sec-rededication-future` reflects the structural position of Section 41 within the closing renewal sequence.
+
+The current physical location of the print was not verified this round. The CNA Steichen Collections site was not fetched this session. The MoMA collection page for Sander's works was not fetched this round.
+
+## Subject and context
+
+Per the MoMA Master Checklist, plate #462 is set in Germany and appears in Section 41 "Couples." The checklist does not describe the subject of the photograph.
+
+August Sander's *Menschen des 20. Jahrhunderts* project included portraits of couples as one of its recognized subject categories — the project's taxonomic scope encompassed "people" across all social types and life stages (verbatim ICP archive page description: "a comprehensive document of the German people," fetched 2026-05-09 and re-confirmed 2026-05-10). Whether plate #462 derives from that project specifically is not stated in the checklist and has not been confirmed from any Tier-1/2 source fetched this round.
+
+The placement of this plate in Section 41 "Couples," in the exhibition's post-Bomb closing arc, positions a German photographer — from the country centrally associated with the catastrophe of World War II — within the exhibition's narrative of renewal and return to human connection. This structural placement is a curatorial observation; no source fetched this round attributes this reading to Steichen or any other named curator.
+
+Steichen's title-deprivation practice — documented in the CNA education portal as Steichen "took the pictures out of their context, deprived them from their title, their date or any mention about their original place" — means any typological category Sander may have assigned to the subjects is absent from the exhibition's presentation.
+
+The smaller format of this plate (18 × 12 1/2 cm) compared to the other Sander plates (both at 28 cm height) is consistent with the use of a different image from the Sander archive — perhaps a more intimate, horizontal-register composition.
+
+## Reception / analysis
+
+No plate-specific critical reception for checklist #462 has been located in any source consulted this round.
+
+Roland Barthes, in "The Great Family of Man" (`src-barthes-1957`, Tier-2, in-repo, fetched 2026-04-19), argues that the exhibition transforms historically contingent social arrangements into natural universals: "This myth of the human 'condition' rests on a very old mystification, which always consists in placing Nature at the bottom of History." The exhibition's closing sequence — placing couples and children after the H-bomb image as a gesture of affirmation — is precisely the structure Barthes critiques. Whether Barthes had any individual plate from Section 41 in mind is not stated in the essay.
+
+The Hurm/Reitz/Zamir volume (`src-hurm-reitz-zamir-2018`, Tier-2, in-repo) includes "a letter by August Sander" among its primary historical documents (per the CNA documentation page, fetched 2026-05-09). The content of that letter was not read in this session; it may bear on how Sander understood his own participation in the exhibition.
+
+## Perspective notes
+
+- **Curatorial (MoMA 1955):** Within the post-Bomb closing arc of Section 41, Sander's couple image contributes Germany's presence to the exhibition's final statement of affirmation. Three Sander plates spread across three sections — Work A, Teens, Couples — represent the broadest temporal range of any single photographer's contribution in this portion of the catalog, spanning labor, adolescence, and partnership.
+- **Critical:** Sander's typological method — cool, distanced, and systematic — sits in tension with the emotional warmth of the exhibition's humanist frame. The Barthes critique (placing "Nature at the bottom of History") is especially acute here: a German couple photographed by Sander in the sociological tradition is placed within a universalizing narrative of renewal after catastrophe.
+
+## Open questions
+
+- The specific subject of plate #462 — which couple, age, or typological category — is not stated in the checklist and has not been confirmed from any Tier-1/2 source in this session.
+- Whether the print currently forms part of the Clervaux Castle holdings (CNA, Luxembourg) was not verified this round.
+- Whether plate #462 corresponds to a known MoMA object ID was not verified this round.
+- The content of the August Sander letter in Hurm/Reitz/Zamir 2018 was not read in this session.


### PR DESCRIPTION
## Summary

Resolves issue #152. Five plate deep-dives paired with the photographer-bios from PRs #195 + #200:

- **photo-0263** — Hamaya, Section 24 Ring Around the Rosy
- **photo-0316** — Feininger, Section 25 Relationships (LIFE-credited, 140×102 cm — among the larger prints)
- **photo-0402** — Sander, Section 35 Teens
- **photo-0435** — Yosuke Yamahata, Section 39 Faces (the 1955 NY plate, **not** one of the 1956-Tokyo-curtained Nagasaki photographs — explicit "Critical distinction" block in bio)
- **photo-0447** — Sander, Section 41 Couples (third of three Sander plates — the only Weimar pre-1933 portrait corpus at this scale in FoM)

## Cache artifacts

5 HTML files in `.scratch/` (ICP archive pages for Hamaya / Yamahata / Sander / Feininger + Magnum Bischof). Per `feedback_subagent_cache_artifacts.md`.

## Validators

- [x] schema OK
- [x] credibility OK
- [x] injection-scan OK
- [x] Pre-commit CoVe verification: SHIP, no required fixes

## Test plan

- [ ] Grounding judge to verify each plate's section assignment via strict-match grep against `data/photographs.csv`
- [ ] Bias judge: Yamahata 1955-NY vs 1956-Tokyo split, Sander Weimar framing
- [ ] Credibility judge: ICP Tier-1 attributions

🤖 Generated with [Claude Code](https://claude.com/claude-code)