### PR TITLE
Gallery: chronological page of all openly-licensed in-repo imagery (1859–2015)

### DIFF
--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -5,6 +5,7 @@
       <a href="{{ '/steichen/' | relative_url }}">Steichen</a>
       <a href="{{ '/exhibition/' | relative_url }}">Exhibition</a>
       <a href="{{ '/photographs/' | relative_url }}">Photographs</a>
+      <a href="{{ '/gallery/' | relative_url }}">Gallery</a>
       <a href="{{ '/photographers/' | relative_url }}">Photographers</a>
       <a href="{{ '/reception/' | relative_url }}">Reception</a>
       <a href="{{ '/bibliography/' | relative_url }}">Sources</a>

--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -1943,3 +1943,137 @@ body.site-search-open {
   font-family: var(--sans);
   font-size: 0.95rem;
 }
+
+/* ---------- Gallery ---------- */
+
+.gallery-intro {
+  padding: 2.5rem 1.25rem 1rem;
+}
+.gallery-intro h1 {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 500;
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  line-height: 1.05;
+  margin: 0 0 0.75rem;
+}
+.gallery-section {
+  padding: 1rem 1.25rem 3rem;
+}
+.era-head {
+  margin: 2.5rem 0 2rem;
+  max-width: 56rem;
+}
+.era-rule {
+  width: 4rem;
+  height: 1px;
+  background: var(--ink);
+  margin-bottom: 1.25rem;
+}
+.era-title {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: clamp(1.6rem, 3.2vw, 2.05rem);
+  line-height: 1.15;
+  letter-spacing: -0.005em;
+  margin: 0 0 0.6rem;
+}
+.era-note {
+  font-family: var(--serif);
+  font-size: 1.05rem;
+  line-height: 1.55;
+  color: var(--mid);
+  margin: 0;
+  max-width: 48rem;
+}
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 22rem), 1fr));
+  gap: clamp(1.25rem, 3vw, 2.5rem);
+}
+.gallery-card {
+  margin: 0;
+  background: var(--paper);
+  border: 1px solid var(--hairline);
+  display: flex;
+  flex-direction: column;
+}
+.gallery-link {
+  color: inherit;
+  text-decoration: none;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+}
+.gallery-link:hover .gallery-image img {
+  transform: scale(1.025);
+}
+.gallery-image {
+  background: var(--mist);
+  border-bottom: 1px solid var(--hairline);
+  aspect-ratio: 4 / 5;
+  overflow: hidden;
+}
+.gallery-image img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: grayscale(1) contrast(1.04);
+  transition: transform 320ms ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .gallery-image img { transition: none; }
+}
+.gallery-caption {
+  padding: 1.1rem 1.15rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  flex: 1 1 auto;
+}
+.gallery-meta-year {
+  font-family: var(--sans);
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--mid);
+}
+.gallery-title {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 1.25rem;
+  line-height: 1.2;
+  margin: 0;
+}
+.gallery-byline {
+  font-family: var(--sans);
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: var(--mid);
+}
+.gallery-source {
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  line-height: 1.4;
+  margin-top: auto;
+  padding-top: 0.5rem;
+}
+.gallery-source a {
+  color: var(--mid);
+  text-decoration: underline;
+  text-decoration-thickness: 0.5px;
+  text-underline-offset: 2px;
+}
+.gallery-source a:hover { color: var(--ink); }
+.gallery-coda {
+  padding: 3rem 1.25rem 5rem;
+  border-top: 1px solid var(--hairline);
+  margin-top: 3rem;
+}
+
+@media print {
+  .gallery-grid { grid-template-columns: 1fr; gap: 1.5rem; }
+  .gallery-card { break-inside: avoid; }
+  .gallery-image img { filter: none; }
+}

--- a/site/gallery.md
+++ b/site/gallery.md
@@ -1,0 +1,379 @@
+---
+layout: default
+title: Gallery
+permalink: /gallery/
+---
+
+<section class="wrap-wide gallery-intro">
+  <div class="home-section-head">
+    <div>
+      <h1>Gallery</h1>
+      <p class="lead">A chronological reading of the exhibition's pre-history, making, touring, and afterlife — through the {{ '25' }} photographs and installation views currently in this wiki under public-domain or Creative-Commons licences. Every plate of the 503 in the show remains under copyright with the photographers' estates and is not hosted here; the gallery surfaces only what is openly licensed, in the order it was taken.</p>
+    </div>
+  </div>
+</section>
+
+<section class="wrap-wide gallery-section" aria-labelledby="era-pre">
+  <div class="era-head">
+    <div class="era-rule"></div>
+    <h2 id="era-pre" class="era-title">1859 – 1922 · Pre-history</h2>
+    <p class="era-note">Photographs from the half-century before <em>The Family of Man</em> that Steichen would gather into the show, alongside his own early Pictorialist work and the Brâncuși friendship that would later shape his curatorial method.</p>
+  </div>
+  <div class="gallery-grid">
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/carroll-1859-alice-queen-of-may.jpg' | relative_url }}" alt="Lewis Carroll's photograph of Alice Liddell as 'The Queen of May', 1859" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">1859</div>
+        <h3 class="gallery-title"><em>Alice Liddell as "The Queen of May"</em></h3>
+        <div class="gallery-byline">Lewis Carroll · Public domain (PD-old)</div>
+        <div class="gallery-source"><a href="https://upload.wikimedia.org/wikipedia/commons/d/d6/Alice_Liddell_as_The_Queen_of_May_by_Lewis_Carroll%2C_1859.jpg" rel="noopener">Wikimedia Commons</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/brady-1861-dead-soldier.jpg' | relative_url }}" alt="Mathew Brady, dead soldier, American Civil War, c. 1861" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">c. 1861</div>
+        <h3 class="gallery-title"><em>Civil War dead</em></h3>
+        <div class="gallery-byline">Mathew Brady · Public domain (pre-1929)</div>
+        <div class="gallery-source"><a href="https://commons.wikimedia.org/wiki/Category:The_Family_of_Man_(Steichen_exhibition)" rel="noopener">Wikimedia Commons</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/steichen-1901-self-portrait.jpg' | relative_url }}" alt="Edward Steichen self-portrait, age 22, gum print, 1901" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">1901</div>
+        <h3 class="gallery-title"><em>Self-portrait, age 22</em></h3>
+        <div class="gallery-byline">Edward Steichen, gum print · Public domain</div>
+        <div class="gallery-source"><a href="https://upload.wikimedia.org/wikipedia/commons/f/fd/Eduard_J._Steichen%2C_self_portrait_1902.jpg" rel="noopener">Wikimedia Commons</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/steichen-1903-jp-morgan.jpg' | relative_url }}" alt="Edward Steichen, photographic portrait of J. Pierpont Morgan, 1903" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">1903</div>
+        <h3 class="gallery-title">J. Pierpont Morgan</h3>
+        <div class="gallery-byline">Edward Steichen · Public domain</div>
+        <div class="gallery-source"><a href="https://commons.wikimedia.org/wiki/File:Edward_Steichen_-_Photographic_portrait_of_Pierpont_Morgan_(1837-1913).jpg" rel="noopener">Wikimedia Commons</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/steichen-1904-pond-moonlight.jpg' | relative_url }}" alt="Edward Steichen, The Pond — Moonlight, 1904" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">1904</div>
+        <h3 class="gallery-title"><em>The Pond — Moonlight</em></h3>
+        <div class="gallery-byline">Edward Steichen, gum-bichromate print · Public domain</div>
+        <div class="gallery-source"><a href="https://commons.wikimedia.org/wiki/File:ThePondMoonlight.jpg" rel="noopener">Wikimedia Commons</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/charlotte-1919-grand-duchess.jpg' | relative_url }}" alt="Charlotte, Grand Duchess of Luxembourg, 1919" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">1919</div>
+        <h3 class="gallery-title">Grand Duchess Charlotte of Luxembourg</h3>
+        <div class="gallery-byline">Photographer unknown · Public domain (PD-old)</div>
+        <div class="gallery-source"><a href="https://commons.wikimedia.org/wiki/File:Charlotte_-_Grand_Duchess_of_Luxembourg.jpg" rel="noopener">Wikimedia Commons</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <a class="gallery-link" href="{{ '/brancusi/' | relative_url }}">
+        <div class="gallery-image">
+          <img src="{{ '/assets/images/brancusi-1922-steichen-portrait.jpg' | relative_url }}" alt="Constantin Brâncuși photographed by Edward Steichen, 1922" loading="lazy">
+        </div>
+        <figcaption class="gallery-caption">
+          <div class="gallery-meta-year">1922</div>
+          <h3 class="gallery-title">Constantin Brâncuși in his Voulangis workshop</h3>
+          <div class="gallery-byline">Edward Steichen · Public domain</div>
+          <div class="gallery-source">Brâncuși and Steichen →</div>
+        </figcaption>
+      </a>
+    </figure>
+  </div>
+</section>
+
+<section class="wrap-wide gallery-section" aria-labelledby="era-fsa">
+  <div class="era-head">
+    <div class="era-rule"></div>
+    <h2 id="era-fsa" class="era-title">1936 – 1944 · The decade of the contributors</h2>
+    <p class="era-note">FSA documentary photography and the Toni Frissell illustration tradition. These four photographs are among the plates Steichen would select for the show two decades after they were taken.</p>
+  </div>
+  <div class="gallery-grid">
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/lange-1936-migrant-mother.jpg' | relative_url }}" alt="Dorothea Lange, Migrant Mother, March 1936" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">March 1936</div>
+        <h3 class="gallery-title"><em>Migrant Mother</em> (Florence Owens Thompson, Nipomo, California)</h3>
+        <div class="gallery-byline">Dorothea Lange, Farm Security Administration · Public domain (PD-USGov)</div>
+        <div class="gallery-source"><a href="{{ '/photographers/pher-dorothea-lange/' | relative_url }}">Lange contributed five plates →</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/delano-1940-tobacco-farmers.jpg' | relative_url }}" alt="Jack Delano, Mr. and Mrs. Andrew Lyman, Polish tobacco farmers near Windsor Locks, Connecticut, September 1940" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">September 1940</div>
+        <h3 class="gallery-title">Mr. and Mrs. Andrew Lyman, Polish tobacco farmers</h3>
+        <div class="gallery-byline">Jack Delano, FSA · Public domain (PD-USGov)</div>
+        <div class="gallery-source"><a href="{{ '/photographers/pher-jack-delano/' | relative_url }}">Delano: 1 plate (#140 Land) →</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/lee-1941-easter-chicago.jpg' | relative_url }}" alt="Russell Lee, Easter morning on the Southside of Chicago, April 1941" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">April 1941</div>
+        <h3 class="gallery-title">Easter morning on the Southside of Chicago</h3>
+        <div class="gallery-byline">Russell Lee, FSA / Office of War Information · Public domain (PD-USGov)</div>
+        <div class="gallery-source"><a href="{{ '/photographers/pher-russell-lee/' | relative_url }}">Lee: 2 plates →</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/frissell-1944-my-shadow.jpg' | relative_url }}" alt="Toni Frissell, My Shadow, from A Child's Garden of Verses, 1944" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">1944</div>
+        <h3 class="gallery-title"><em>My Shadow</em>, from A Child's Garden of Verses</h3>
+        <div class="gallery-byline">Toni Frissell, LOC Toni Frissell Collection · No known restrictions on publication</div>
+        <div class="gallery-source"><a href="https://commons.wikimedia.org/wiki/Category:The_Family_of_Man_(Steichen_exhibition)" rel="noopener">Wikimedia Commons</a></div>
+      </figcaption>
+    </figure>
+  </div>
+</section>
+
+<section class="wrap-wide gallery-section" aria-labelledby="era-navy">
+  <div class="era-head">
+    <div class="era-rule"></div>
+    <h2 id="era-navy" class="era-title">1943 – 1945 · The Naval Aviation Photographic Unit</h2>
+    <p class="era-note">The crucible where Steichen — by then in his sixties — built the curatorial method that <em>The Family of Man</em> would inherit. Steichen commanded the unit; Wayne Miller served under him as a combat photographer; both would later collaborate on the 1955 exhibition.</p>
+  </div>
+  <div class="gallery-grid">
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/steichen-1943-lexington.jpg' | relative_url }}" alt="Cmdr Edward Steichen on the deck of USS Lexington, November 1943, photograph by Lt Victor Jorgensen" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">November 1943</div>
+        <h3 class="gallery-title">Cmdr Steichen above the deck of USS Lexington</h3>
+        <div class="gallery-byline">Lt Victor Jorgensen, U.S. Navy · Public domain (PD-USGov)</div>
+        <div class="gallery-source"><a href="https://commons.wikimedia.org/wiki/File:Steichen_above_Lexington,_by_Jorgensen,_11-1943.png" rel="noopener">Wikimedia Commons</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/steichen-guam-1945.jpg' | relative_url }}" alt="Capt. E. J. Steichen photographing children on Guam, c. March 1945" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">c. March 1945</div>
+        <h3 class="gallery-title">Capt. Steichen photographing children on Guam</h3>
+        <div class="gallery-byline">U.S. Navy combat photograph, NARA · Public domain (PD-USGov)</div>
+        <div class="gallery-source"><a href="https://commons.wikimedia.org/wiki/File:Capt._E.J._Steichen,_Navy_combat_photographer,_photographs_native_children_on_Guam_Island_-_NARA_-_520630.jpg" rel="noopener">Wikimedia Commons</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/miller-1945-uss-ticonderoga.jpg' | relative_url }}" alt="Lt. Wayne Miller in his quarters aboard the USS Ticonderoga, 1945" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">1945</div>
+        <h3 class="gallery-title">Lt. Wayne Miller aboard USS Ticonderoga</h3>
+        <div class="gallery-byline">U.S. Navy combat photograph, NARA item 520842 · Public domain (PD-USGov)</div>
+        <div class="gallery-source"><a href="{{ '/photographers/pher-wayne-miller/' | relative_url }}">Steichen's 1953 curatorial assistant →</a></div>
+      </figcaption>
+    </figure>
+  </div>
+</section>
+
+<section class="wrap-wide gallery-section" aria-labelledby="era-show">
+  <div class="era-head">
+    <div class="era-rule"></div>
+    <h2 id="era-show" class="era-title">1948 – 1961 · The exhibition and its tour</h2>
+    <p class="era-note">Installation photographs (USIA / NARA) capturing how Paul Rudolph's 1955 design was re-fabricated for the world tour, plus Carl Sandburg — author of the prologue distributed as a leaflet to every visitor.</p>
+  </div>
+  <div class="gallery-grid">
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/family-of-man-layout.jpg' | relative_url }}" alt="Family of Man tour exhibit installation layout" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">1948 – 1967 (tour-era)</div>
+        <h3 class="gallery-title">Tour-edition installation: Rudolph's design re-fabricated by USIA</h3>
+        <div class="gallery-byline">U.S. National Archives, Still Pictures · Public domain (PD-USGov)</div>
+        <div class="gallery-source"><a href="{{ '/exhibition/' | relative_url }}">Rudolph's design, Steichen's curation →</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/moma-1955-opening.jpg' | relative_url }}" alt="Family of Man tour exhibit installation, &quot;Opening Day&quot;" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">1948 – 1967 (tour-era)</div>
+        <h3 class="gallery-title">Tour-edition installation: "Opening Day"</h3>
+        <div class="gallery-byline">U.S. National Archives, Still Pictures · Public domain (PD-USGov)</div>
+        <div class="gallery-source"><a href="{{ '/world-tour/' | relative_url }}">The 1955 – 62 USIA world tour →</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/sandburg-1955-nywts.jpg' | relative_url }}" alt="Carl Sandburg, 1955, photographed for the New York World Telegram" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">1955</div>
+        <h3 class="gallery-title">Carl Sandburg, author of the prologue</h3>
+        <div class="gallery-byline">Al Ravenna / World Telegram, LOC NYWT&amp;S Collection · No known restrictions on publication</div>
+        <div class="gallery-source"><a href="https://commons.wikimedia.org/wiki/File:Carl_Sandburg_NYWTS.jpg" rel="noopener">Wikimedia Commons</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/family-of-man-schoolchildren.jpg' | relative_url }}" alt="Schoolchildren viewing a tour-edition installation of The Family of Man" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">1961 – 1979 (USAID dating window)</div>
+        <h3 class="gallery-title">Schoolchildren at a tour-edition installation</h3>
+        <div class="gallery-byline">USIA staff photograph, NARA · Public domain (PD-USGov)</div>
+        <div class="gallery-source"><a href="{{ '/world-tour/' | relative_url }}">The 1955 – 62 USIA world tour →</a></div>
+      </figcaption>
+    </figure>
+  </div>
+</section>
+
+<section class="wrap-wide gallery-section" aria-labelledby="era-after">
+  <div class="era-head">
+    <div class="era-rule"></div>
+    <h2 id="era-after" class="era-title">1965 – 1969 · The afterlife begins</h2>
+    <p class="era-note">Three years after Szarkowski took over MoMA Photography from Steichen, the curatorial succession captured at the 1965 White House Festival of the Arts. Rudolph in his Yale chairmanship years. Barthes — three years after the English translation of <em>Mythologies</em> reached Anglophone reception — at the height of the structuralist moment.</p>
+  </div>
+  <div class="gallery-grid">
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/rudolph-1965-loc-portrait.jpg' | relative_url }}" alt="Paul Rudolph, seated portrait, 1965" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">1965</div>
+        <h3 class="gallery-title">Paul Rudolph, in his Yale chairmanship years</h3>
+        <div class="gallery-byline">LOC Paul Rudolph Archive · No known restrictions on publication</div>
+        <div class="gallery-source"><a href="https://www.loc.gov/item/2024633891/" rel="noopener">Library of Congress</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/szarkowski-1965-white-house.jpg' | relative_url }}" alt="John Szarkowski (centre), Joanna Steichen, and Edward Steichen at the 1965 White House Festival of the Arts" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">1965</div>
+        <h3 class="gallery-title">Szarkowski, Joanna and Edward Steichen, White House Festival</h3>
+        <div class="gallery-byline">Marion S. Trikosko, LOC U.S. News &amp; World Report Collection · No known restrictions</div>
+        <div class="gallery-source"><a href="https://www.loc.gov/item/2016647270/" rel="noopener">Library of Congress</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/barthes-1969-dagens-nyheter.jpg' | relative_url }}" alt="Roland Barthes photographed for Dagens Nyheter, 27 February 1969" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">27 February 1969</div>
+        <h3 class="gallery-title">Roland Barthes</h3>
+        <div class="gallery-byline">Photo for <em>Dagens Nyheter</em> · Public domain</div>
+        <div class="gallery-source"><a href="{{ '/reception/' | relative_url }}">"La grande famille des hommes" (1957) →</a></div>
+      </figcaption>
+    </figure>
+  </div>
+</section>
+
+<section class="wrap-wide gallery-section" aria-labelledby="era-clervaux">
+  <div class="era-head">
+    <div class="era-rule"></div>
+    <h2 id="era-clervaux" class="era-title">2005 – 2015 · The Clervaux home</h2>
+    <p class="era-note">The collection's permanent installation at Clervaux Castle — Steichen's personal request that the U.S. donate the last complete touring edition to Luxembourg in 1964; inaugurated 1994, restored 2010 – 2013, listed by UNESCO as Memory of the World in 2003.</p>
+  </div>
+  <div class="gallery-grid">
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/clervaux-castle.jpg' | relative_url }}" alt="Clervaux Castle exterior, Luxembourg, 25 March 2005" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">25 March 2005</div>
+        <h3 class="gallery-title">Clervaux Castle exterior</h3>
+        <div class="gallery-byline">Donar Reiskoffer · CC BY-SA 3.0 (Wikimedia Commons)</div>
+        <div class="gallery-source"><a href="https://commons.wikimedia.org/wiki/File:Luxembourg,_Clervaux,_Castle2.JPG" rel="noopener">Wikimedia Commons</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/clervaux-signage.jpg' | relative_url }}" alt="Family of Man permanent installation signage at Clervaux Castle, 8 September 2006" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">8 September 2006</div>
+        <h3 class="gallery-title">Permanent installation signage at Clervaux</h3>
+        <div class="gallery-byline">Joachim Köhler · CC BY-SA 3.0 (Wikimedia Commons)</div>
+        <div class="gallery-source"><a href="https://commons.wikimedia.org/wiki/File:Clerf-FamilyOfMan-20060908.JPG" rel="noopener">Wikimedia Commons</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/clervaux-2013-interior.jpg' | relative_url }}" alt="Clervaux Castle interior, Family of Man permanent installation, 2013" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">2013</div>
+        <h3 class="gallery-title">Interior, Clervaux installation (post-restoration)</h3>
+        <div class="gallery-byline">Gorup de Besanez · CC BY-SA 4.0 (Wikimedia Commons)</div>
+        <div class="gallery-source"><a href="{{ '/clervaux/' | relative_url }}">The Clervaux home →</a></div>
+      </figcaption>
+    </figure>
+
+    <figure class="gallery-card">
+      <div class="gallery-image">
+        <img src="{{ '/assets/images/clervaux-2015-rg72-interior.jpg' | relative_url }}" alt="Clervaux Castle interior, Family of Man permanent installation, 7 August 2015" loading="lazy">
+      </div>
+      <figcaption class="gallery-caption">
+        <div class="gallery-meta-year">7 August 2015</div>
+        <h3 class="gallery-title">Interior, Clervaux installation</h3>
+        <div class="gallery-byline">RG72 · CC BY-SA 4.0 (Wikimedia Commons)</div>
+        <div class="gallery-source"><a href="{{ '/clervaux/' | relative_url }}">The Clervaux home →</a></div>
+      </figcaption>
+    </figure>
+  </div>
+</section>
+
+<section class="wrap-wide gallery-coda">
+  <div class="home-section-head">
+    <div>
+      <h2>What this gallery does not show</h2>
+      <p class="lead">The 503 photographs of <em>The Family of Man</em> itself are copyrighted by their photographers and estates. This wiki does not host them — see the per-plate <a href="{{ '/photographs/' | relative_url }}">photographs index</a> for descriptive entries linking out to the institutions that hold prints (primarily the Museum of Modern Art and the Centre national de l'audiovisuel at Clervaux). When more photographs of the show's making, tour, or afterlife enter the public domain or are released under open licences, they will be added to the gallery in chronological position.</p>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
Resolves the user's 2026-05-10 priority request *"prioritize the gallery page with all images that we have in istoric order"* and partially addresses [#162](https://github.com/danlex/thefamilyofman/issues/162) (the full 503-plate gallery design spec).

## What this is

A new `/gallery/` page that walks the show's pre-history, making, touring, and afterlife through the **25 photographs and installation views currently in this wiki under public-domain or Creative-Commons licences**, in the order each was taken. Six era buckets, hairline-bordered cards, masonry-aware grid, lazy-loaded images.

## Era buckets and counts

| Era | Years | Cards |
|---|---|---|
| Pre-history | 1859 – 1922 | 7 (Carroll, Brady, Steichen × 3, Charlotte, Brâncuși) |
| Decade of the contributors | 1936 – 1944 | 4 (Lange, Delano, Lee, Frissell) |
| Naval Aviation Photographic Unit | 1943 – 1945 | 3 (Steichen Lexington, Steichen Guam, Miller Ticonderoga) |
| Exhibition and tour | 1948 – 1961 | 4 (USIA installation × 2, Sandburg, schoolchildren) |
| Afterlife begins | 1965 – 1969 | 3 (Rudolph, Szarkowski, Barthes) |
| Clervaux home | 2005 – 2015 | 4 (castle exterior, signage, interior × 2) |
| **Total** | | **25** |

## Design — restraint over decoration

Honors the design direction from #162's spec, scoped down to the imagery we currently host:

- **Palette**: existing `--ink` / `--paper` / `--mist` / `--hairline` CSS variables. No gradients, no shadows.
- **Typography**: serif (EB Garamond stack) for era titles + plate titles; sans-serif small-caps for year metadata; sans-serif for bylines and source citations.
- **Layout**: `grid-template-columns: repeat(auto-fill, minmax(min(100%, 22rem), 1fr))` with `gap: clamp(1.25rem, 3vw, 2.5rem)`. Hairline borders, no shadows. 4 / 5 image aspect-ratio holders prevent layout shift.
- **Image treatment**: native `loading="lazy"`, `filter: grayscale(1) contrast(1.04)`, subtle 1.025× hover scale that respects `prefers-reduced-motion`.
- **Caption pattern**: year tag (small caps), title (serif italic where appropriate), byline + licence, source link. Three lines.
- **Print stylesheet**: `@media print` switches to single-column, removes the grayscale filter, prevents card-break-inside. Renders as a clean exhibition-catalog excerpt.
- **Coda**: explicit "what this gallery does not show" — the 503 photographs of the show itself remain copyrighted by their estates and are linked out at the per-plate level.

## Files

- `site/gallery.md` (new, 379 lines)
- `site/assets/css/style.css` — Gallery section appended (~134 lines)
- `site/_includes/header.html` — primary nav adds /gallery/ between Photographs and Photographers

## What's *not* in this PR (deferred from #162's full spec)

- A 503-row data-pipeline + filter UI (year / photographer / section / country) — those depend on having images for many more plates. Currently only ~25 plates of the 503 are openly-licensed in-repo, so a 503-row gallery would be 95% empty placeholders. The MVP here surfaces what we *can* show beautifully; the full spec is the right north-star for when image rights expand.
- A new layout file at `site/_layouts/gallery.html` and a `gallery-card.html` partial — at 25 cards inline rendering is simpler and shippable.
- A `scripts/generate_gallery_data.py` data pipeline — same reason: not yet warranted.

## Validators

- [x] `python3 scripts/validate_schema.py` → schema OK
- [x] `python3 scripts/check_credibility.py` → credibility OK (272 / 215)
- [x] `python3 scripts/check_injection_patterns.py` → injection-scan OK
- [x] `python3 scripts/check_cache_artifacts.py .` → cache-artifact audit OK (no source/research changes)

## Test plan

- [ ] Reviewer: navigate to `/gallery/` and visually verify the six era sections render in chronological order.
- [ ] Reviewer: confirm hover state on a card image is subtle (1.025× scale only) and that `prefers-reduced-motion` disables the transition.
- [ ] Reviewer: print-preview the page and confirm it renders as a single-column exhibition-catalog excerpt.
- [ ] Reviewer: confirm primary nav now shows Gallery between Photographs and Photographers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)