### PR TITLE
ci: Jekyll-mirror audit gate (prevention follow-up to #236/#237)

### DIFF
--- a/.github/workflows/audit-jekyll-mirror.yml
+++ b/.github/workflows/audit-jekyll-mirror.yml
@@ -1,0 +1,22 @@
+name: Audit Jekyll mirror
+
+on:
+  pull_request:
+    paths:
+      - 'sources/**'
+      - 'site/_sources/**'
+      - 'scripts/audit_jekyll_mirror.py'
+      - '.github/workflows/audit-jekyll-mirror.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run mirror audit
+        run: python3 scripts/audit_jekyll_mirror.py

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .claude/worktrees/
 .claude/dataset-curator-queue.jsonl
 .scratch/
+__pycache__/
+*.pyc


### PR DESCRIPTION
## What

Adds `.github/workflows/audit-jekyll-mirror.yml` — a read-only CI check that runs `scripts/audit_jekyll_mirror.py` on any PR touching `sources/**`, `site/_sources/**`, the audit script, or the workflow file. Also gitignores `__pycache__/` / `*.pyc`.

## Why

#236 found 73 silent divergences between canonical `sources/` and the `site/_sources/` Jekyll mirror (incl. the load-bearing MoMA Master Checklist stuck 2 days behind on the live site). #237 resynced and added the audit script but left it manual. This wires it in so the drift **can't reaccumulate unnoticed**.

## Safety

- `permissions: contents: read` — no write token, no side effects.
- Pure-stdlib script, already in repo and passing (`272 == 272`, audit OK).
- Triggers only on relevant paths + `workflow_dispatch`.

## ⚠️ CI change — held for explicit approval

Per this project's autonomous-execution convention, CI changes are **not self-merged**. This PR is opened for review; merge is gated on your approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)