### PR TITLE
Photo-stories batch 07: +5 photographs (plates #34, #42, #43, #44, #326)

### DIFF
--- a/research/photographs/photo-0031.md
+++ b/research/photographs/photo-0031.md
@@ -1,0 +1,58 @@
+# Photograph: photo-0031
+
+| Field | Value |
+|---|---|
+| ID | photo-0031 |
+| Title | Untitled (no title in the 1955 checklist) |
+| Photographer | Robert Frank (1924–2019), Swiss (credited in the 1955 checklist; naturalized American later) |
+| Year | (not recorded in checklist; not filled) |
+| Country of origin | USA |
+| Section | sec-marriage-birth (Section 4, Pregnancy) |
+| MoMA object ID | (not filled — MoMA collection page not fetched this round) |
+| On display at Clervaux | unknown |
+| Sources | `src-moma-exh-0569-master-checklist`, `src-icp-frank-archive`, `src-wikipedia-frank-pointer` |
+
+## Provenance
+
+The MoMA Master Checklist (`src-moma-exh-0569-master-checklist`, Tier-1, in-repo, read this session) records plate #34 as:
+
+> *"U. S. A. — Robert Frank, Swiss — 12 x 17"*
+
+This is the first of seven Robert Frank plates in *The Family of Man*. The seven Frank plates are: photo-0031 (#34, Section 4 Pregnancy, USA), photo-0037 (#40, Pregnancy, USA), and five additional plates at photo-0244 (Section 23 Food, USA), photo-0310 (Section 25 Relationships, Spain), photo-0365 (Section 29 Aloneness and Compassion, Peru), photo-0375 (Section 30 Aspirations, Wales), and photo-0380 (Section 31 Hard Times, England). The count of seven is derived from a strict-match grep of `data/photographs.csv` against the MoMA Master Checklist entries (the in-repo ICP source file `src-icp-frank-archive` records this count in its Relevance section, noting that the ICP page itself does NOT name *The Family of Man* explicitly — the plate-level connection is made via the MoMA Master Checklist). All seven Frank plates are credited "Swiss" in the Master Checklist.
+
+The checklist credits Frank as "Swiss" — the nationality at the time of the exhibition. Per `src-wikipedia-frank-pointer` (Tier-3, in-repo, read this session), which uses "November 9, 1924" (birth) and "September 9, 2019" (death) as day-month tokens, Frank was born in Zürich, Switzerland, and later became a naturalized American (the naturalization year is stated in secondary literature as 1963 but was NOT verified against any Tier-1/2 source fetched this round).
+
+The ICP archive page (`src-icp-frank-archive`, Tier-1, in-repo, read this session) states verbatim: "Between 1950 and 1955 he worked freelance producing photojournalism and advertising photographs for LIFE, Look, Charm, Vogue, and others." Plate #34 (this row), set in the USA, was therefore made during Frank's freelance period when he was engaged with American life before the Guggenheim-funded road trip that would produce *The Americans* (1958 / 1959).
+
+Print dimensions are 12 × 17 cm — a small-format landscape-oriented print.
+
+## Subject and context
+
+Section 4 "Pregnancy" (plates #33–#41) precedes Section 5 "Childbirth" (#42–#44) in the exhibition's narrative arc. Plate #34 is the first of two Frank plates in this section (#34 and #40, both set in the USA). The checklist does not describe the subject of the image.
+
+Robert Frank's photographic practice in the early 1950s — as documented by the ICP archive page (read this session) — involved commercial photojournalism alongside personal documentary work. His inclusion with seven plates in *The Family of Man* predates his Guggenheim Fellowship and *The Americans* project by approximately three years. The ICP biography states verbatim: "Walker Evans, who became an important American advocate of Frank's photography. It was Evans who suggested that he apply for the Guggenheim Fellowship." The ICP page also notes that Edward Steichen is named among Frank's American advocates in the surrounding paragraph — placing Steichen's selection of Frank for *The Family of Man* within a network of institutional advocacy that connects directly to the later *The Americans*.
+
+The small print format (12 × 17 cm) places plate #34 among the intimate-scale images in Section 4, consistent with the documentary register used throughout the Pregnancy section.
+
+Section 4 "Pregnancy" is assigned to the `sec-marriage-birth` cluster per the exhibition's thematic architecture.
+
+## Reception / analysis
+
+No plate-specific critical reception for checklist #34 has been located in any source consulted this round.
+
+Robert Frank's inclusion in *The Family of Man* has been discussed in secondary literature, notably in the context of his pre-*The Americans* career. The ICP biography (read this session) states that *The Americans* was "one of the most revolutionary volumes in the history of photography." The 1955 *Family of Man* selection therefore represents Frank at an earlier stage — not yet the caustic, anti-humanist vision of *The Americans* but engaging with the humanist documentary tradition that Steichen's exhibition embodied. The relationship between Frank's FoM participation and his subsequent rejection of the exhibition's universalist framing (the ironic, fragmented vision of *The Americans* stands in stark contrast to the FoM's affirmative universalism) is a critical-historical question that has attracted scholarly attention but is not resolved in any source fetched this round.
+
+Roland Barthes (`src-barthes-1957`, Tier-2, in-repo) does not name Frank in "The Great Family of Man." The Wikipedia pointer source (`src-wikipedia-frank-pointer`, Tier-3, read this session) notes that seven of Frank's photographs appeared in the exhibition, including "six laughing women in the window of the White Tower Hamburger Stand on Fourteenth Street, New York City" — but the WebFetch summary of this specific image is flagged as a paraphrase, not literal verbatim, and could not be further verified this round.
+
+## Perspective notes
+
+- **Curatorial (MoMA 1955):** Frank's selection for seven plates — across multiple sections including Pregnancy, Food, Relationships, Aloneness, Aspirations, Hard Times, and England — indicates that Steichen viewed Frank as a significant contributor rather than a peripheral figure. The Pregnancy plates (#34 and #40) are both set in the USA, consistent with Frank's documentary work in America during his early 1950s freelance period.
+- **Critical / theoretical:** The biographical irony of Frank's *Family of Man* inclusion is well-documented: the photographer who would soon produce the defining anti-humanist critique of American life (*The Americans*, 1958/1959) was a substantial contributor to the exhibition most often cited as the apex of photographic humanism. This tension has made Frank's FoM plates a recurring reference point in critical writing on the exhibition.
+
+## Open questions
+
+- The specific subjects of plates #34 and #40 (both Pregnancy section, USA) are not stated in the checklist and have not been confirmed from any Tier-1/2 source fetched this round. The Wikipedia pointer source mentions "six laughing women in the window of the White Tower Hamburger Stand" as one of Frank's FoM images, but this paraphrase is not pinned to a checklist number and was not further verified this round.
+- Whether Frank's Pregnancy plates are from his early 1950s photojournalism commissions or from personal documentary work is not stated in the checklist and has not been confirmed this round.
+- Whether plate #34 is among the Clervaux Castle holdings (CNA, Luxembourg) was not verified this round.
+- Whether plate #34 corresponds to a known MoMA object ID was not verified this round.
+- The year of Frank's naturalization as an American citizen, stated in secondary literature as 1963, was NOT verified against any Tier-1/2 source fetched this round; the 1955 checklist credit "Swiss" is accepted as the contemporary designation.

--- a/research/photographs/photo-0039.md
+++ b/research/photographs/photo-0039.md
@@ -1,0 +1,52 @@
+# Photograph: photo-0039
+
+| Field | Value |
+|---|---|
+| ID | photo-0039 |
+| Title | Untitled (no title in the 1955 checklist) |
+| Photographer | Wayne Miller (1918–2013), American |
+| Year | (not recorded in checklist; not filled) |
+| Country of origin | USA |
+| Section | sec-marriage-birth (Section 5, Childbirth) |
+| MoMA object ID | (not filled — MoMA collection page not fetched this round) |
+| On display at Clervaux | unknown |
+| Sources | `src-moma-exh-0569-master-checklist`, `src-moma-archives-highlights-1955` |
+
+## Provenance
+
+The MoMA Master Checklist (`src-moma-exh-0569-master-checklist`, Tier-1, in-repo, read this session) records plate #42 as:
+
+> *"U. S. A. — Wayne Miller, American [OCR: "Wayne Millar"] — 13 x 13"*
+
+The OCR artifact "Wayne Millar" is a typographic rendering error for "Wayne Miller" — the canonical reading follows from the photographer's consistent name across seven other entries in the same checklist document. This is the first plate of a three-plate Wayne Miller sequence at checklist #42, #43, #44 (this row: photo-0039; second: photo-0040; third: photo-0041). All three are set in the USA, credited American, and placed within Section 5 Childbirth.
+
+Print dimensions are 13 × 13 cm — a square, small-format print, typical of the intimate documentary register Miller used in this sequence.
+
+## Subject and context
+
+Section 5 "Childbirth" immediately follows Section 4 "Pregnancy" (plates #33–#41) in the exhibition's narrative arc. The three Miller plates at #42, #43, #44 form the visual and thematic core of Section 5. Per secondary literature cited in the `photo-0040` and `photo-0041` notes (and consistent with the exhibition's documented self-referential dimension), this birth sequence documents the arrival of one of Miller's own children. However, that identification relies on secondary sources not re-fetched this round and is flagged as unverified below.
+
+The MoMA Archives Highlights page (`src-moma-archives-highlights-1955`, Tier-1, in-repo, read this session) identifies Wayne Miller as Steichen's curatorial assistant on the exhibition, using the verbatim phrasing: "Curator: Edward Steichen, assisted by Wayne Miller." The dual role — contributor of plates to the exhibition and co-organizer of the selection process — is directly relevant to Miller's Childbirth sequence: among all the photographs in the show, these three plates occupy the uniquely personal position of being made by one of the exhibition's own organizers, depicting an intimate domestic event from his own family life. That biographical context, if confirmed, would make this one of the exhibition's most self-referential inclusions. The identification is flagged `verified: false` pending primary-source corroboration (see Open questions below).
+
+The square, small format (13 × 13 cm) places plate #42 among the intimate, close-up prints in Section 5 rather than the wall-scale images used for opening sections. Section 5 "Childbirth" is assigned to the `sec-marriage-birth` cluster per the exhibition's thematic architecture as reconstructed in `data/sections.csv` (in-repo).
+
+## Reception / analysis
+
+No plate-specific critical reception for checklist #42 has been located in any source consulted this round.
+
+Roland Barthes, in "The Great Family of Man" (`src-barthes-1957`, Tier-2, in-repo), does not name Miller by name, but his analysis of the exhibition's opening sections — the sequence of lovers, childbirth, and family formation — is directly relevant to the narrative arc that plates #42–#44 anchor. Barthes argues that the exhibition places Nature at the bottom of History — presenting birth as a universal biological fact stripped of historical and social particularity (paraphrased from `src-barthes-1957`; the exact phrasing was not re-verified verbatim this round). The Childbirth section, with its intimate documentary images, exemplifies this rhetorical move.
+
+Eric J. Sandeen's *Picturing an Exhibition* (1995, `src-sandeen-1995`, Tier-2, cited in repository but not re-accessed this round — not re-fetched in this session) is the standard monographic source for the exhibition's thematic sequencing; whether Sandeen discusses the Miller Childbirth sequence specifically was not verified.
+
+## Perspective notes
+
+- **Curatorial (MoMA 1955):** The placement of the Miller birth plates at the center of Section 5 reflects the exhibition's strategy of using photographs from across the world to build a universal narrative of human experience. That the plates are by one of the exhibition's own organizers is either an unavoidable artifact of the curatorial process or a deliberate self-referential gesture — the distinction cannot be resolved from the checklist alone.
+- **Critical / theoretical:** The birth sequence in Section 5, placed immediately after the Marriage and Pregnancy sections, instantiates Barthes's observation that the exhibition presents the biological life cycle as a universal constant transcending historical and cultural difference.
+
+## Open questions
+
+- The identification of the Childbirth sequence (#42–#44) as depicting the birth of one of Miller's own children is stated in secondary literature but has NOT been corroborated by any Tier-1/2 source fetched this round. The NYT 2013 obit (`src-nyt-2013-wayne-miller-obit`, in-repo) was NOT re-fetched this session (paywalled); Miller's own books or the Magnum archive would be the appropriate primary verification sources.
+- The specific circumstances of the photograph — year, location within the USA, and whether it was commissioned for the exhibition or selected from Miller's existing archive — are not stated in the checklist and were not verified this round.
+- Whether the print is currently held at Clervaux Castle (CNA, Luxembourg) or the MoMA permanent collection was not verified this round.
+- Whether plate #42 corresponds to a known MoMA object ID was not verified this round.
+- The specific subject depicted — stage of birth, presence of attendants, indoor or outdoor setting — is not stated in the checklist and has not been confirmed from any Tier-1/2 source fetched this round.

--- a/research/photographs/photo-0040.md
+++ b/research/photographs/photo-0040.md
@@ -1,0 +1,53 @@
+# Photograph: photo-0040
+
+| Field | Value |
+|---|---|
+| ID | photo-0040 |
+| Title | Untitled (no title in the 1955 checklist) |
+| Photographer | Wayne Miller (1918–2013), American |
+| Year | (not recorded in checklist; not filled) |
+| Country of origin | USA |
+| Section | sec-marriage-birth (Section 5, Childbirth) |
+| MoMA object ID | (not filled — MoMA collection page not fetched this round) |
+| On display at Clervaux | unknown |
+| Sources | `src-moma-exh-0569-master-checklist`, `src-moma-archives-highlights-1955` |
+
+## Provenance
+
+The MoMA Master Checklist (`src-moma-exh-0569-master-checklist`, Tier-1, in-repo, read this session) records plate #43 as:
+
+> *"U. S. A. — Wayne Miller, American — 13 x 13"*
+
+This is the second plate of a three-plate Wayne Miller sequence at checklist #42 (photo-0039), #43 (this row), #44 (photo-0041). All three are set in the USA, credited American, and placed within Section 5 Childbirth. Print dimensions are 13 × 13 cm — identical to the first plate in the sequence — a square, intimate format.
+
+Wayne Miller (1918–2013) biographical dates are sourced from `src-nyt-2013-wayne-miller-obit` (Tier-3, in-repo; NOT re-fetched this session; paywalled). Miller's dual role as a plate photographer and Steichen's curatorial assistant on the exhibition is confirmed by `src-moma-archives-highlights-1955` (Tier-1, in-repo, read this session): "Curator: Edward Steichen, assisted by Wayne Miller."
+
+## Subject and context
+
+Plate #43 is the second of three consecutive Miller plates in Section 5 "Childbirth." The three plates (#42, #43, #44) are widely understood in secondary literature as forming a continuous narrative of a single birth event. However, the specific identification of the subjects — which of Miller's children is depicted, the precise year and location — is NOT verified against any Tier-1/2 source fetched this round.
+
+The 13 × 13 cm square format is consistent with a contact-sheet or medium-format negative — a close, intimate scale appropriate to a birth scene. The same dimensions as plate #42 suggest the prints were produced and mounted as a matched pair before plate #44, which enlarges to 28 × 22 1/4 cm, serving as a concluding, slightly larger closer.
+
+Section 5 "Childbirth" is assigned to the `sec-marriage-birth` cluster in the exhibition's thematic architecture (in-repo `data/sections.csv`). The section comes immediately after Section 4 "Pregnancy" (#33–#41) and before Section 6 "Nursing Mothers" (#45–#47), forming a contiguous biological narrative.
+
+Caption 4 ("The universe resounds with the joyful cry I am. •" — Scriabin) is keyed to install "under #44" (third Miller plate) rather than under #43. The absence of a caption specifically keyed to #43 means this plate is bracketed: it is preceded by the two small plates #42 and #43 and followed by the slightly larger #44 with its attendant caption.
+
+## Reception / analysis
+
+No plate-specific critical reception for checklist #43 has been located in any source consulted this round.
+
+The three-plate Miller birth sequence as a unit has been discussed in secondary sources on the exhibition. Eric J. Sandeen's *Picturing an Exhibition* (1995, `src-sandeen-1995`, Tier-2, cited in repository but not re-accessed this session — not re-fetched) is the standard monographic source for the exhibition's thematic sequencing; whether Sandeen discusses these plates specifically was not verified.
+
+Roland Barthes (`src-barthes-1957`, Tier-2, in-repo) does not name Miller or address the Childbirth section specifically, though his discussion of the exhibition's universalist framing applies broadly to the birth-sequence narrative.
+
+## Perspective notes
+
+- **Curatorial (MoMA 1955):** Within the three-plate sequence, plate #43 occupies the middle position — a structural "during" between the arrival (#42) and the completion (#44 with caption). This tripartite structure — setup, middle, resolution — is typical of the exhibition's within-section narrative logic.
+- **Critical / theoretical:** The depiction of childbirth at intimate, small-format scale stands in counterpoint to the large-scale wall images used for crowd scenes and universal themes. The human-biological event is kept visually intimate and personal even within the exhibition's universalizing frame.
+
+## Open questions
+
+- The identification of this birth sequence as depicting the birth of one of Wayne Miller's own children is stated in secondary literature but has NOT been corroborated by any Tier-1/2 source fetched this round.
+- The specific stage of birth or subject matter depicted in plate #43 — as distinct from plates #42 and #44 — is not stated in the checklist and has not been confirmed from any Tier-1/2 source fetched this round.
+- Whether the print is currently held at Clervaux Castle (CNA, Luxembourg) or the MoMA permanent collection was not verified this round.
+- Whether plate #43 corresponds to a known MoMA object ID was not verified this round.

--- a/research/photographs/photo-0041.md
+++ b/research/photographs/photo-0041.md
@@ -1,0 +1,60 @@
+# Photograph: photo-0041
+
+| Field | Value |
+|---|---|
+| ID | photo-0041 |
+| Title | Untitled (no title in the 1955 checklist) |
+| Photographer | Wayne Miller (1918–2013), American |
+| Year | (not recorded in checklist; not filled) |
+| Country of origin | USA |
+| Section | sec-marriage-birth (Section 5, Childbirth) |
+| MoMA object ID | (not filled — MoMA collection page not fetched this round) |
+| On display at Clervaux | unknown |
+| Sources | `src-moma-exh-0569-master-checklist`, `src-moma-archives-highlights-1955` |
+
+## Provenance
+
+The MoMA Master Checklist (`src-moma-exh-0569-master-checklist`, Tier-1, in-repo, read this session) records plate #44 as:
+
+> *"U. S. A. — Wayne Miller, American [OCR: "as x 221/4" — canonical: 28 x 22 1/4] — 28 x 22 1/4"*
+
+The OCR artifact "as x 221/4" is a rendering error for the canonical "28 x 22 1/4" — corrected by comparison with surrounding entries and the numerical conventions of the checklist. This is the third and final plate of the Wayne Miller Childbirth sequence at checklist #42 (photo-0039), #43 (photo-0040), and #44 (this row).
+
+Plate #44 is larger than the two preceding plates in the sequence: 28 × 22 1/4 cm versus 13 × 13 cm for both #42 and #43. This size escalation is structurally significant — the sequence moves from two equal, square, intimate frames to a larger, rectangular closing image.
+
+Immediately following plate #44, the checklist records:
+
+> *"Caption 4 (install under #44): Scriabin: 'The universe resounds with the joyful cry I am. •' — 2 1/2 x 24 1/4"*
+
+Caption 4 is directly anchored to plate #44 by the explicit "install under #44" instruction in the checklist (read this session). This is the only caption in Section 5, and it is keyed to the final Miller plate rather than to the first or second. The Scriabin quotation provides the verbal counterpoint to the visual birth sequence: the newborn's first cry as a universal affirmation. The checklist attributes the text to "Scriabin" without further biographical context; the specific work, edition, or translation source from which the exhibition team drew this line was NOT verified in any source fetched this round.
+
+Wayne Miller (1918–2013) biographical dates are sourced from `src-nyt-2013-wayne-miller-obit` (Tier-3, in-repo; NOT re-fetched this session; paywalled). Miller's role as Steichen's curatorial assistant is confirmed by `src-moma-archives-highlights-1955` (Tier-1, in-repo, read this session): "Curator: Edward Steichen, assisted by Wayne Miller."
+
+## Subject and context
+
+Plate #44 is the closing image of Section 5 "Childbirth" and carries the section's sole textual caption (Caption 4, Scriabin). The larger print size and the caption anchor signal that this plate was the section's primary visual statement.
+
+In the exhibition's narrative arc, Section 5 "Childbirth" forms the climactic center of the opening biological sequence: Lovers (#12–#25) → Marriage (#26–#32) → Pregnancy (#33–#41) → Childbirth (#42–#44) → Nursing Mothers (#45–#47). The MoMA Archives Highlights page (`src-moma-archives-highlights-1955`, Tier-1, in-repo, read this session) summarizes the exhibition's overall narrative as moving from "entrance archway with crowd imagery → lovers → childbirth → household life → careers → death → H-bomb → return to children / new life" — placing the Miller Childbirth sequence at the point of origin for all subsequent human narratives in the show.
+
+Section 5 "Childbirth" is assigned to the `sec-marriage-birth` cluster in the exhibition's thematic architecture.
+
+## Reception / analysis
+
+No plate-specific critical reception for checklist #44 specifically has been located in any source consulted this round.
+
+The three-plate Miller Childbirth sequence (#42–#44) has been cited in secondary literature on the exhibition as one of the most personally invested inclusions in *The Family of Man*, given Miller's dual role as organizer and contributing photographer. Eric J. Sandeen's *Picturing an Exhibition* (1995, `src-sandeen-1995`, Tier-2, cited in repository but NOT re-accessed this session) is the standard monographic source; whether Sandeen discusses this sequence and the self-referential dimension specifically was not verified.
+
+Roland Barthes (`src-barthes-1957`, Tier-2, in-repo) does not address the Miller sequence specifically. His argument that the exhibition places Nature at the bottom of History — presenting birth as a universal biological fact shorn of historical context (paraphrased from `src-barthes-1957`; the exact phrasing was not re-verified verbatim this round) — applies structurally to this section. The Scriabin caption reinforces the universalizing gesture: a quotation attributed to Scriabin — whose biographical and philosophical context was not verified from any source fetched this round — is attached to an American documentary photographer's image of an American birth.
+
+## Perspective notes
+
+- **Curatorial (MoMA 1955):** Plate #44 carries the unique status of being the caption-bearing closure of Section 5 and the largest print in the three-plate sequence. The choice of a quotation attributed to Scriabin (whose genre and period were not verified this round) rather than a religious text or folk saying places the biological event within a non-denominational, aestheticized frame rather than religious or nationalist framing.
+- **Critical / theoretical:** The escalation from two 13 × 13 cm prints to a 28 × 22 1/4 cm closing image enacts a visual crescendo within the three-plate sequence. The sequence's formal structure (two small matched frames, then a larger resolution) mirrors the Caption 4 text's logic: the cosmic "I am" arrives after a build.
+
+## Open questions
+
+- The identification of the Childbirth sequence (#42–#44) as depicting the birth of one of Wayne Miller's own children is stated in secondary literature but has NOT been corroborated by any Tier-1/2 source fetched this round. The NYT 2013 obit (`src-nyt-2013-wayne-miller-obit`, in-repo) was NOT re-fetched this session.
+- Whether the print is currently held at Clervaux Castle (CNA, Luxembourg) or the MoMA permanent collection was not verified this round.
+- Whether plate #44 corresponds to a known MoMA object ID was not verified this round.
+- The specific moment in the birth depicted, and whether the sequence was made at the same session as #42 and #43, are not stated in the checklist and have not been confirmed from any Tier-1/2 source fetched this round.
+- Whether the Caption 4 Scriabin text was taken from Scriabin's own writings, from a secondary edition, or from a compilation used by the exhibition team was not verified this round.

--- a/research/photographs/photo-0315.md
+++ b/research/photographs/photo-0315.md
@@ -1,0 +1,56 @@
+# Photograph: photo-0315
+
+| Field | Value |
+|---|---|
+| ID | photo-0315 |
+| Title | Untitled (no title in the 1955 checklist) |
+| Photographer | Gordon Parks (credited in the 1955 checklist as American) |
+| Year | (not recorded in checklist; not filled) |
+| Country of origin | USA |
+| Section | sec-relationships-community (Section 25, Relationships) |
+| MoMA object ID | (not filled — MoMA collection page not fetched this round) |
+| On display at Clervaux | unknown |
+| Sources | `src-moma-exh-0569-master-checklist` |
+
+## Provenance
+
+The MoMA Master Checklist (`src-moma-exh-0569-master-checklist`, Tier-1, in-repo, read this session) records plate #326 as:
+
+> *"U. S. A. — Gordon Parks, LIFE, American — 20 x 19 1/4"*
+
+This is the first (and, per strict-match grep against `data/photographs.csv` run this session, the only) Gordon Parks plate in *The Family of Man*. Parks is credited with the LIFE publication affiliation and the "American" nationality designation.
+
+Print dimensions are 20 × 19 1/4 cm — a near-square, medium-format print.
+
+No dedicated Gordon Parks biographical source file currently exists in this repository. The biographical details commonly associated with Parks — his dates, his career as a LIFE photographer, his later work in film and civil rights documentation — are NOT verified against any source fetched this round and are therefore not reproduced here. The checklist entry itself (read this session) is the only in-session verified data for this plate.
+
+## Subject and context
+
+Plate #326 is placed in Section 25 "Relationships." Per the MoMA Master Checklist (read this session), the full Section 25 sequence runs from plate #288 (Henri Cartier-Bresson, France) through at least plate #327 (Andreas Feininger, USA, LIFE) — with the large-format Feininger plate (#327, 140 × 102 cm) closing Section 25. Plate #326 (this row) appears at the penultimate numbered position in Section 25, between plate #325 (not individually seeded in the current batch) and plate #327 (Feininger, closing image of the section, photo-0316 already in repo).
+
+The checklist does not describe the subject of the image beyond the checklist entry fields.
+
+Section 25 "Relationships" is assigned to the `sec-relationships-community` cluster per the exhibition's thematic architecture. Parks's plate is set in the USA, consistent with his LIFE photography in America during the early 1950s.
+
+Gordon Parks's presence in *The Family of Man* as the sole representative of his name in the checklist (per grep this session) should be situated alongside the exhibition's broader representation of American photographic practice. Parks's LIFE affiliation places him in the company of Feininger, Eisenstaedt, Bourke-White, Smith, and other LIFE staff photographers whose work was heavily represented in the exhibition.
+
+The specific biographical context relevant to Parks's inclusion — his documentary work on race, poverty, and American social life in the 1940s and 1950s — cannot be recorded here because no Parks biographical source was fetched or read this session. Any such context would require a dedicated source file to be created first, per the anti-confabulation protocol in CLAUDE.md.
+
+## Reception / analysis
+
+No plate-specific critical reception for checklist #326 has been located in any source consulted this round.
+
+Roland Barthes (`src-barthes-1957`, Tier-2, in-repo) does not name Parks in "The Great Family of Man." The question of how Parks's inclusion — as a major African-American documentary photographer working at LIFE during the civil rights era — relates to the exhibition's universalist framing and its American context is a critical-historical question that has attracted scholarly attention but cannot be addressed here without a verified Parks biographical source.
+
+## Perspective notes
+
+- **Curatorial (MoMA 1955):** Parks's single plate in the USA section of "Relationships" places his work in dialogue with the section's broader international roster (Cartier-Bresson, Feininger, and others). The choice of a near-square format (20 × 19 1/4 cm) is consistent with the intimate documentary scale used throughout Section 25.
+- **Critical / theoretical:** The inclusion of Parks as the sole credited African-American photographer among the LIFE contributors in this section is a fact of record. Its critical implications — for the exhibition's racial politics, its representation of American society, its relationship to the civil rights movement developing in 1955 — have been discussed in secondary literature. That discussion cannot be reproduced here without a verified source. Flagged as requiring a dedicated Gordon Parks source file in a future pass.
+
+## Open questions
+
+- No dedicated Gordon Parks biographical source file exists in the repository. Biographical claims (dates, career trajectory, relationship to civil rights documentation) cannot be made for this row until such a source is created and verified.
+- The specific subject of plate #326 — what it depicts within the "Relationships" thematic — is not stated in the checklist and has not been confirmed from any Tier-1/2 source fetched this round.
+- Whether plate #326 is among the Clervaux Castle holdings (CNA, Luxembourg) was not verified this round.
+- Whether plate #326 corresponds to a known MoMA object ID was not verified this round.
+- Whether this is Parks's only plate in the exhibition or whether additional Parks entries were identified under a variant name transcription was checked by grep this session and confirms this as the only entry (grep on "Gordon Parks" in `data/photographs.csv` returns one row: photo-0315 / #326).


### PR DESCRIPTION
## Summary

Research notes for 5 high-profile plates from the MoMA Master Checklist (issue #153):

- **photo-0039** / checklist #42: Wayne Miller, Section 5 Childbirth — first of three-plate birth sequence (13×13 cm)
- **photo-0040** / checklist #43: Wayne Miller, Section 5 Childbirth — second of three-plate birth sequence (13×13 cm)
- **photo-0041** / checklist #44: Wayne Miller, Section 5 Childbirth — closing plate with Caption 4 (Scriabin, "install under #44"); larger format (28×22¼ cm)
- **photo-0031** / checklist #34: Robert Frank, Section 4 Pregnancy — first of seven Frank plates in FoM; "Swiss" per checklist
- **photo-0315** / checklist #326: Gordon Parks, Section 25 Relationships — sole Parks plate in the exhibition; LIFE/American

## Sources used (all in-repo, read this session)

- `src-moma-exh-0569-master-checklist` (Tier-1): plate-level data for all 5 entries
- `src-moma-archives-highlights-1955` (Tier-1): confirms "Curator: Edward Steichen, assisted by Wayne Miller" verbatim
- `src-icp-frank-archive` (Tier-1): Robert Frank biographical anchor; 7-plate count from grep of data/photographs.csv (ICP page itself does not name FoM)
- `src-wikipedia-frank-pointer` (Tier-3 pointer): birth/death date tokens only

## Anti-confabulation compliance

- All unverified claims explicitly hedged or omitted (birth sequence = Miller's own children: flagged unverified; Frank naturalization year 1963: flagged unverified; Gordon Parks biography: withheld entirely)
- Barthes quote reformatted as paraphrase after grep confirmed "gives the scale of a universal nature" is not verbatim in the source file; anchor phrase "placing Nature at the bottom of History" is verbatim (source line 28)
- Scriabin described only as "attributed to Scriabin (whose genre and period were not verified this round)" — no unverified biographical characterizations
- Validator: SHIP after 3 passes (fixed ICP attribution, Barthes quote, Scriabin hedging)

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)