### PR TITLE
Photo-stories batch 06: +5 photographs (photo-0015, photo-0017, photo-0021, photo-0026, photo-0037)

### DIFF
--- a/research/photographs/photo-0015.md
+++ b/research/photographs/photo-0015.md
@@ -1,0 +1,55 @@
+# Photograph: photo-0015
+
+| Field | Value |
+|---|---|
+| ID | photo-0015 |
+| Title | Untitled (no title in the 1955 checklist) |
+| Photographer | Roy DeCarava (1919–2009), American |
+| Year | (not recorded in checklist; not filled) |
+| Country of origin | USA |
+| Section | sec-lovers (Section 2, Lovers) |
+| MoMA object ID | (not filled — MoMA collection page not fetched this round) |
+| On display at Clervaux | unknown |
+| Sources | `src-moma-exh-0569-master-checklist`, `src-nyt-2009-decarava-obit` |
+
+## Provenance
+
+The MoMA Master Checklist (`src-moma-exh-0569-master-checklist`, Tier-1, in-repo, read this session) records plate #18 as:
+
+> *"U. S. A. — Roy De Carava, American [OCR: 'De Carave'] — 16 x 11"*
+
+The OCR artifact "De Carave" is noted; the canonical form on the checklist page is "Roy De Carava" (two words), per the Relevance section of the in-repo checklist source which notes the OCR rendering. The photographer is the same individual whose canonical name is "Roy DeCarava" (one word) per later sources including his own estate; the checklist spelling "De Carava" reflects 1955 typographic practice.
+
+This is the only plate in Section 2 (Lovers) attributed to DeCarava. The section runs from plate #12 to plate #25. The MoMA Master Checklist (read this session) records four DeCarava plates: #18, #147, #232, and #301. Note: `data/photographers.csv` currently records `photo_count: 3` — this reflects that `data/photographs.csv` contains only three rows for DeCarava (photo-0015, photo-0141, photo-0223); checklist plate #301 has not yet been assigned a CSV row. The checklist primary record of four plates is authoritative; the CSV count is an underfill pending future expansion. Plate #18 is his sole Lovers-section entry.
+
+Print dimensions are 16 × 11 cm — a small-format portrait-oriented print.
+
+## Subject and context
+
+Section 2 "Lovers" (plates #12–#25) presents intimate human relationships at the exhibition's opening, following the cosmological and biological prologue. The section includes work by Dmitri Kessel, Robert Doisneau (three plates), Gotthard Schuh, Louis Faurer (two plates), Ernst Haas, and others. The Joyce caption (Caption 2, installed under plate #19) frames the section: *"• • • and then I asked him with my eyes to ask again yes. • •"*
+
+Roy DeCarava's single Lovers-section plate (16 × 11 cm, USA) appears at position #18 in the sequence. The checklist does not describe the image's subject. Given DeCarava's documentary practice centered on Harlem and African-American life, and his placement by Steichen at position #18 within the Lovers section — between plate #17 (Lou Bernstein, USA) and plate #19 (Gotthard Schuh, Italy) — the image is consistent with his photographic record of everyday Black life in New York in the early 1950s.
+
+DeCarava had received the Guggenheim Fellowship in 1952 — the first awarded to an African-American photographer, per `data/photographers.csv` (which carries this claim from `src-nyt-2009-decarava-obit`, `verified: false`). His *The Sweet Flypaper of Life*, a collaboration with Langston Hughes, was published in 1955, the same year as the exhibition. Both facts are carried from `src-nyt-2009-decarava-obit` (Tier-3, in-repo, not re-fetched this round; marked `verified: false` in that source file — the NYT paywall blocked re-verification).
+
+Steichen's selection of DeCarava — alongside his curatorial positioning in the Lovers sequence — reflects the exhibition's explicit ambition to represent the full range of American experience, not an exclusively white documentary canon.
+
+## Reception / analysis
+
+No plate-specific critical reception for checklist #18 has been located in any source consulted this round.
+
+Roland Barthes (`src-barthes-1957`, in-repo, Tier-2) does not name DeCarava in "The Great Family of Man." The Barthes essay's critique of the exhibition's universalism — its "myth of the human community" that suppresses historical difference — is particularly charged in relation to DeCarava's placement in the exhibition: his images of Black American life were absorbed into an affirmative universalist frame at a moment when civil rights conflicts were acute in the United States.
+
+The DeCarava obituary source (`src-nyt-2009-decarava-obit`, Tier-3, in-repo, `verified: false`) notes his 1996 MoMA retrospective — placing the 1955 FoM inclusion early in a career whose institutional recognition by MoMA came four decades later.
+
+## Perspective notes
+
+- **Curatorial (MoMA 1955):** DeCarava's placement in the Lovers section at a small-format, intimate scale (16 × 11 cm) is consistent with the section's visual register. Steichen placed him between Lou Bernstein (USA) and Gotthard Schuh (Italy/Switzerland), integrating a Black American photographer's vision of intimacy into the universal love sequence without section-level framing or differentiation.
+- **Critical / theoretical:** The biographical context — 1952 Guggenheim, 1955 *Sweet Flypaper of Life* with Langston Hughes, 1996 MoMA retrospective — marks DeCarava as a photographer recognized both inside and outside the FoM frame. His participation has been noted in scholarship on race and photography at mid-century.
+
+## Open questions
+
+- The specific subject of plate #18 is not stated in the checklist and has not been confirmed from any Tier-1/2 source fetched this round.
+- Whether plate #18 is among the Clervaux Castle holdings (CNA, Luxembourg) was not verified this round.
+- Whether plate #18 corresponds to a known MoMA permanent-collection object ID was not verified this round.
+- The claims about the 1952 Guggenheim Fellowship and 1955 *Sweet Flypaper of Life* are carried from `src-nyt-2009-decarava-obit` (`verified: false`); they have not been re-verified against any Tier-1/2 source fetched this round.

--- a/research/photographs/photo-0017.md
+++ b/research/photographs/photo-0017.md
@@ -1,0 +1,64 @@
+# Photograph: photo-0017
+
+| Field | Value |
+|---|---|
+| ID | photo-0017 |
+| Title | Untitled (no title in the 1955 checklist) |
+| Photographer | Robert Doisneau (1912–1994), French |
+| Year | (not recorded in checklist; not filled) |
+| Country of origin | France |
+| Section | sec-lovers (Section 2, Lovers) |
+| MoMA object ID | (not filled — MoMA collection page not fetched this round) |
+| On display at Clervaux | unknown |
+| Sources | `src-moma-exh-0569-master-checklist`, `src-lemonde-1994-doisneau-obit` |
+
+## Provenance
+
+The MoMA Master Checklist (`src-moma-exh-0569-master-checklist`, Tier-1, in-repo, read this session) records plate #20 as:
+
+> *"France — Robert Doisneau, Rapho Guillumette (agency), French — 16 x 13"*
+
+This is the third of three Doisneau plates in Section 2 (Lovers). The full Doisneau sequence in this section runs:
+
+- Plate #14 — France — Robert Doisneau, Rapho Guillumette (agency), French — 18 x 21 1/4
+- Plate #16 — France — Robert Doisneau, Rapho Guillumette (agency), French — 12 x 14
+- Plate #20 — France — Robert Doisneau, Rapho Guillumette (agency), French — 16 x 13 *(this plate)*
+
+Doisneau contributed five plates to the exhibition in total (plates #14, #16, #20 in Lovers; plates #234 and #248 in later sections — per `data/photographers.csv`). Plate #20 is his third appearance within the Lovers section, which is an unusually dense clustering: three plates from a single photographer within a 9-plate range (positions #12–#20).
+
+All three Lovers-section plates share the geographic designation France and the Rapho Guillumette agency credit. Doisneau's photo_count in `data/photographers.csv` is recorded as 5.
+
+Print dimensions are 16 × 13 cm — a small-format portrait-oriented print.
+
+## Subject and context
+
+Section 2 "Lovers" (plates #12–#25) encompasses intimate pairings from multiple countries (China, England, France, New Guinea, USA, Italy, Switzerland). Doisneau's three plates — all France-located — anchor the section's French-humanist register. The Joyce caption (Caption 2, installed under plate #19 Gotthard Schuh, Italy) frames the emotional arc of the Lovers section: *"• • • and then I asked him with my eyes to ask again yes. • •"*
+
+Plate #20 at position #20 in the checklist falls just before the Joyce quotation panel (Caption 2 at #19) and after the other Doisneau plates. The small format (16 × 13 cm) places it among the intimate-scale prints.
+
+Robert Doisneau worked for the Rapho Guillumette agency — a Paris-based cooperative founded in 1933 that handled many of the leading French humanist photographers including Willy Ronis, Édouard Boubat, Izis (Israël Bidermanas), and Doisneau himself. His agency credit in the checklist aligns with the agency affiliation standard in `data/photographers.csv`.
+
+Biographical anchor: Doisneau was born 14 April 1912 in Gentilly (Seine, today Val-de-Marne), France, and died 1 April 1994 in Montrouge (Hauts-de-Seine), France, per `src-lemonde-1994-doisneau-obit` (Tier-3, in-repo, `verified: false`; Le Monde paywall prevents re-verification). The death year 1994 and the dates April 14 / April 1 are carried from that source only.
+
+The `data/photographers.csv` note for Doisneau records: *"The famously titled 'Le Baiser de l'Hôtel de Ville' (1950) is not confirmed as any of these three plates at the plate level — see notes on photo-0011."* The connection between Doisneau's most celebrated image and any specific FoM plate has not been established in any source fetched this round.
+
+## Reception / analysis
+
+No plate-specific critical reception for checklist #20 has been located in any source consulted this round.
+
+Roland Barthes's critique in "The Great Family of Man" (`src-barthes-1957`, Tier-2, in-repo) engages with the exhibition's universalizing humanist project and names no individual photographers. Doisneau represents precisely the French humanist-photography tradition that Barthes was simultaneously critiquing in the broader cultural context of *Mythologies* (1957). The three Doisneau plates in the Lovers section embody the affirmative vision of Parisian street life and romantic intimacy that had become a signature of French humanist photography by 1955.
+
+The *Le Monde* obituary source (`src-lemonde-1994-doisneau-obit`, Tier-3, in-repo, `verified: false`) places Doisneau at the center of the French humanist-photography school alongside Henri Cartier-Bresson, Willy Ronis, and Édouard Boubat.
+
+## Perspective notes
+
+- **Curatorial (MoMA 1955):** The clustering of three Doisneau plates (at positions #14, #16, and #20) within a 9-plate section is one of the highest single-photographer densities in any section of the exhibition. Steichen's selection reflects a deliberate editorial weighting of French humanist photography in the section most explicitly devoted to love and intimacy.
+- **Critical / theoretical:** Doisneau's inclusion, and the concentration of his work in the Lovers section, makes the section a site of French photographic exceptionalism within an ostensibly universal exhibition — a tension that tracks the Paris exhibition's own reception, where French critics noted both the universalism and the implicit American-editorial frame.
+
+## Open questions
+
+- The specific subjects of plates #14, #16, and #20 are not stated in the checklist and have not been confirmed from any Tier-1/2 source fetched this round.
+- Whether any of the three Lovers-section Doisneau plates is "Le Baiser de l'Hôtel de Ville" (1950) has not been confirmed from any source fetched this round; the photographers.csv note explicitly flags this as unresolved.
+- Whether plate #20 is among the Clervaux Castle holdings (CNA, Luxembourg) was not verified this round.
+- Whether plate #20 corresponds to a known MoMA permanent-collection object ID was not verified this round.
+- Biographical day-month tokens (April 14, 1912 / April 1, 1994) are carried from `src-lemonde-1994-doisneau-obit` (`verified: false`); not re-verified against any Tier-1/2 source this round.

--- a/research/photographs/photo-0021.md
+++ b/research/photographs/photo-0021.md
@@ -1,0 +1,58 @@
+# Photograph: photo-0021
+
+| Field | Value |
+|---|---|
+| ID | photo-0021 |
+| Title | Untitled (no title in the 1955 checklist) |
+| Photographer | Ernst Haas (1921–1986), Austrian (per 1955 checklist); also credited "American" by ICP post-naturalization |
+| Year | (not recorded in checklist; not filled) |
+| Country of origin | USA |
+| Section | sec-lovers (Section 2, Lovers) |
+| MoMA object ID | (not filled — MoMA collection page not fetched this round) |
+| On display at Clervaux | unknown |
+| Sources | `src-moma-exh-0569-master-checklist`, `src-icp-ernst-haas-archive`, `src-haas-estate-biography`, `src-nyt-1986-haas-obit` |
+
+## Provenance
+
+The MoMA Master Checklist (`src-moma-exh-0569-master-checklist`, Tier-1, in-repo, read this session) records plate #24 as:
+
+> *"U. S. A. — Ernst Haas, Magnum, Austrian [OCR: 'Austr:l.an'] — 16 x 24"*
+
+The OCR artifact "Austr:l.an" is noted; the canonical reading is "Austrian." The nationality in the checklist reflects Haas's citizenship status at the time of the 1955 exhibition; Haas had moved to the United States in 1951 but had not yet naturalized.
+
+Haas contributed six plates to the exhibition in total, per `data/photographers.csv` (count verified by strict-match grep against `data/photographs.csv` 2026-05-09): photo-0021 (#24 Lovers, USA), photo-0147 (#154 Work A, USA), photo-0235 (#244 Dance, New Mexico), photo-0287 (#298 Relationships, USA), photo-0329 (#341 Learning, USA), photo-0437 (#452 post-Faces / pre-Bomb bridge, Italy). Plate #24 is his sole Lovers-section entry.
+
+Print dimensions are 16 × 24 cm — a small-format landscape-oriented print set in the USA.
+
+**Nationality discrepancy:** The MoMA Master Checklist records "Austrian"; the ICP archive page (`src-icp-ernst-haas-archive`, Tier-1, in-repo, read this session) renders "American"; the Haas Estate biography (`src-haas-estate-biography`, Tier-1, in-repo, read this session) opens "Haas was born in Vienna in 1921" without assigning a nationality string. The 1955 checklist credit "Austrian" is accepted as the contemporary primary record. The ICP page's "American" reflects post-naturalization status. See `data/photographers.csv` for the full discrepancy note.
+
+## Subject and context
+
+Section 2 "Lovers" (plates #12–#25) is the exhibition's first thematic section after the cosmological prologue. Haas's plate (#24, USA) appears near the section's close, after the French humanist sequence (Doisneau at #14, #16, #20; Schuh/Italy at #19; Joyce Caption 2 at #19) and alongside the two Louis Faurer USA plates (#23 and #25). The geographic designation USA for Haas's plate aligns with his 1951 relocation to New York and his early documentation of American life for LIFE magazine.
+
+The ICP archive page (`src-icp-ernst-haas-archive`, Tier-1, in-repo, read this session) states verbatim: *"His 'Magic Images of New York,' a twenty-four-page color photo essay, which appeared in LIFE in 1951 was both his and LIFE's first long color feature in print."* The Haas Estate biography (`src-haas-estate-biography`, Tier-1, in-repo, read this session) gives the same New York essay a 1953 date: *"In 1953 LIFE magazine published his groundbreaking 24-page color photo essay on New York City."* Both refer to the same LIFE color essay; the 1951 vs. 1953 discrepancy is recorded but not adjudicated here.
+
+The inclusion of Haas in the Lovers section — at position #24, with a USA-located image — occurs at the intersection of his Magnum membership, his New York period, and his emerging reputation as a color pioneer. The FoM plate predates both his Magnum presidency (1959–60, per `src-icp-ernst-haas-archive`: *"Haas served as president of Magnum in 1959-60"*) and his 1962 MoMA color retrospective (per `src-haas-estate-biography`: *"In 1962 a retrospective of his work was the first color photography exhibition held at New York's Museum of Modern Art"*).
+
+Haas joined Magnum in 1949, per both ICP and the Estate: the ICP page states verbatim *"This prompted Robert Capa to invite Haas to join the Magnum agency"*; the Estate states *"At the invitation of Robert Capa, Haas joined Magnum in 1949, developing close associations with Capa, Henri Cartier-Bresson, and Werner Bishof [sic]."* Robert Capa, who is also represented in *The Family of Man* (plate #26, Section 3 Marriage, Czechoslovakia), was therefore a connecting figure between Haas's institutional membership and his FoM inclusion.
+
+## Reception / analysis
+
+No plate-specific critical reception for checklist #24 has been located in any source consulted this round.
+
+Roland Barthes's critique ("The Great Family of Man," `src-barthes-1957`, Tier-2, in-repo) does not name Haas. The Barthes essay's central argument — that the exhibition transforms historical and political difference into a myth of natural humanity — is pertinent to Haas's placement in the Lovers section: his Austrian origins, 1955 status as a recently-arrived immigrant to the USA, and Magnum affiliation are collapsed into a generic American romantic image.
+
+The 1986 NYT obituary source (`src-nyt-1986-haas-obit`, Tier-3, in-repo, `verified: false`) confirms the career arc; the biographical dates (2 March 1921 / 12 September 1986) are carried from that source only and not re-verified against any Tier-1/2 source fetched this round.
+
+## Perspective notes
+
+- **Curatorial (MoMA 1955):** Haas's six-plate distribution across Lovers, Work A, Dance, Relationships, Learning, and a late-exhibition bridge section signals that Steichen treated him as one of the exhibition's most versatile contributors. His sole Lovers plate (#24, USA, 16 × 24 cm) is the smallest-format of his six, placed at the section's close within a USA cluster (Faurer #23 and #25, Miller #22).
+- **Critical / theoretical:** The 1955–1986 Haas trajectory — from FoM Lovers-section contributor to Magnum president to pioneer of color photography to 1986 Hasselblad laureate — makes plate #24 an early marker in a career whose full significance was not yet apparent at the exhibition's January 1955 opening.
+
+## Open questions
+
+- The specific subject of plate #24 is not stated in the checklist and has not been confirmed from any Tier-1/2 source fetched this round. The USA location and Haas's early-1950s New York practice suggest the subject may be from his New York-period street photography, but this is not verified.
+- Whether plate #24 is among the Clervaux Castle holdings (CNA, Luxembourg) was not verified this round.
+- Whether plate #24 corresponds to a known MoMA permanent-collection object ID was not verified this round.
+- The 1951 vs. 1953 date discrepancy for Haas's first LIFE color essay is not adjudicated here.
+- Biographical day-month tokens (2 March 1921 / 12 September 1986) are carried from `src-nyt-1986-haas-obit` (`verified: false`); not re-verified against any Tier-1/2 source this round.

--- a/research/photographs/photo-0026.md
+++ b/research/photographs/photo-0026.md
@@ -1,0 +1,64 @@
+# Photograph: photo-0026
+
+| Field | Value |
+|---|---|
+| ID | photo-0026 |
+| Title | Untitled (no title in the 1955 checklist) |
+| Photographer | Wayne Miller (1918–2013), American |
+| Year | (not recorded in checklist; not filled) |
+| Country of origin | Mexico |
+| Section | sec-marriage-birth (Section 3, Marriage) |
+| MoMA object ID | (not filled — MoMA collection page not fetched this round) |
+| On display at Clervaux | unknown |
+| Sources | `src-moma-exh-0569-master-checklist`, `src-nyt-2013-wayne-miller-obit` |
+
+## Provenance
+
+The MoMA Master Checklist (`src-moma-exh-0569-master-checklist`, Tier-1, in-repo, read this session) records plate #29 as:
+
+> *"Mexico — Wayne Miller, LIFE, American — 24 x 34 3/4"*
+
+This is the second of Wayne Miller's appearances in the checklist's early sections. His other early entries are:
+
+- Plate #22 — U. S. A. — Wayne Miller, American [OCR: "~lavne Mil1.er"] — 16 x 20 (Section 2 Lovers)
+- Plate #29 — Mexico — Wayne Miller, LIFE, American — 24 x 34 3/4 (Section 3 Marriage) *(this plate)*
+- Plate #42 — U. S. A. — Wayne Miller, American — 13 x 13 (Section 5 Childbirth)
+- Plate #43 — U. S. A. — Wayne Miller, American — 13 x 13 (Section 5 Childbirth)
+- Plate #44 — U. S. A. — Wayne Miller, American — 28 x 22 1/4 (Section 5 Childbirth)
+
+Miller contributed twelve plates to the exhibition in total, per `data/photographers.csv`. Six appear in the first 47 checklist numbers. The high density of his plates in the early sections (Lovers through Childbirth) may reflect his co-curatorial access during preparation, though this connection is not asserted in any Tier-1 source fetched this round.
+
+Plate #29 is distinguished within Miller's sequence by two features: it is the only Mexico-located plate in his twelve; and it is the only one credited to LIFE magazine rather than listed without an agency. The LIFE credit aligns with the magazine affiliation recorded in `data/photographers.csv` and in the NYT obituary source.
+
+Print dimensions are 24 × 34 3/4 cm — a medium-format landscape-oriented print, larger than his surrounding Section 3 neighbors (#27 Horvat, India, 14 × 10 3/4 cm; #28 Malmberg, Sweden, 20 × 18 1/2 cm; #30 Bischof, Japan, 18 × 12 cm).
+
+**On Miller's curatorial role:** The NYT obituary source (`src-nyt-2013-wayne-miller-obit`, Tier-3, in-repo, `verified: false`) states his "co-curatorial role on *The Family of Man* alongside Edward Steichen." However, the source-file note for that record includes an explicit correction: *"the press release does NOT name Wayne Miller at all, and the checklist records him only as photographer of plates #22, #29, #42, #43, #44, #47 — not as curatorial staff. Miller's curatorial role is asserted in the secondary literature (Sandeen 1995, Steichen's 1963 autobiography) but was not re-fetched in this round."* Miller's curatorial role is therefore NOT asserted here as verified fact.
+
+## Subject and context
+
+Section 3 "Marriage" (plates #26–#32) follows the Pregnancy section's anticipatory arc. The section contains work by Robert Capa (Czechoslovakia), Frank Horvat (India), Hans Malmberg (Sweden), Wayne Miller (Mexico), Werner Bischof (Japan), Henri Cartier-Bresson (France), and Jay Te Winburn (USA). The Pueblo Indian caption (Caption 3, installed top-left of plate #27): *"He shall be one person."*
+
+Miller's Mexico plate (#29) is the only non-USA, non-European image by an American photographer in the section. Its 24 × 34 3/4 cm format — notably wider than the surrounding prints — gives it a horizontal landscape prominence within the section wall.
+
+Wayne Miller's biographical anchor: born 19 September 1918, Chicago, Illinois; died 22 May 2013, Orinda, California, per `src-nyt-2013-wayne-miller-obit` (Tier-3, in-repo, `verified: false`; day-month tokens not re-verified against any Tier-1/2 source this round). The obituary notes his later presidency of Magnum Photos (1962–1966) — postdating the exhibition by seven years.
+
+The LIFE agency credit at plate #29 connects Miller to the photojournalism circuit operating in Latin America in the early 1950s. The subject of the Mexico image is not stated in the checklist.
+
+## Reception / analysis
+
+No plate-specific critical reception for checklist #29 has been located in any source consulted this round.
+
+The `data/photographers.csv` entry for Miller notes his twelve-plate distribution and six early-section plates. His prominence in the sequence — across Lovers, Marriage, Childbirth, and later sections — is unusual for a single photographer and may reflect the editorial weight given to his work in the exhibition, but no Tier-1/2 source fetched this round characterizes that weighting explicitly.
+
+## Perspective notes
+
+- **Curatorial (MoMA 1955):** Miller's twelve-plate distribution is among the highest in the exhibition. His Mexico plate (#29) in Section 3 Marriage, at medium-format landscape dimensions, is his most geographically distant from his USA-centered work. The LIFE credit at plate #29 situates it within professional photojournalism rather than personal documentary work.
+- **Critical / theoretical:** The concentration of Miller's plates in the Life-cycle sections (Lovers → Marriage → Childbirth → Nursing Mothers) creates a biographical arc that Steichen wove across the exhibition's opening sequence. Whether this reflects a deliberate editorial program or the availability of Miller's archive is not stated in any source consulted this round.
+
+## Open questions
+
+- The specific subject of plate #29 (Mexico) is not stated in the checklist and has not been confirmed from any Tier-1/2 source fetched this round.
+- Wayne Miller's role as Steichen's curatorial assistant is asserted in secondary literature (Sandeen 1995, Steichen 1963 autobiography per `src-nyt-2013-wayne-miller-obit`) but was NOT verified against any Tier-1/2 source fetched this round. The in-repo press release and checklist do not record this role.
+- Whether plate #29 is among the Clervaux Castle holdings (CNA, Luxembourg) was not verified this round.
+- Whether plate #29 corresponds to a known MoMA permanent-collection object ID was not verified this round.
+- Biographical day-month tokens (September 19, 1918 / May 22, 2013) are carried from `src-nyt-2013-wayne-miller-obit` (`verified: false`); not re-verified this round.

--- a/research/photographs/photo-0037.md
+++ b/research/photographs/photo-0037.md
@@ -1,0 +1,58 @@
+# Photograph: photo-0037
+
+| Field | Value |
+|---|---|
+| ID | photo-0037 |
+| Title | Untitled (no title in the 1955 checklist) |
+| Photographer | Robert Frank (1924–2019), Swiss (credited in the 1955 checklist; naturalized American later) |
+| Year | (not recorded in checklist; not filled) |
+| Country of origin | USA |
+| Section | sec-marriage-birth (Section 4, Pregnancy) |
+| MoMA object ID | (not filled — MoMA collection page not fetched this round) |
+| On display at Clervaux | unknown |
+| Sources | `src-moma-exh-0569-master-checklist`, `src-icp-frank-archive`, `src-wikipedia-frank-pointer` |
+
+## Provenance
+
+The MoMA Master Checklist (`src-moma-exh-0569-master-checklist`, Tier-1, in-repo, read this session) records plate #40 as:
+
+> *"U. S. A. — Robert Frank, Swiss — 13 x 16 1/4"*
+
+This is the second of Robert Frank's two plates in Section 4 (Pregnancy). The first is photo-0031 (plate #34, also USA, 12 × 17 cm). Frank contributed seven plates to the exhibition in total, per `data/photographers.csv` (count verified by strict-match grep against `data/photographs.csv` 2026-05-07): photo-0031 (Pregnancy, USA), photo-0037 (Pregnancy, USA) *(this plate)*, photo-0244 (Food, USA), photo-0310 (Relationships, Spain), photo-0365 (Aloneness and Compassion, Peru), photo-0375 (Aspirations, Wales), photo-0380 (Hard Times, England). All seven plates are credited "Swiss" in the Master Checklist.
+
+Plate #40 at 13 × 16 1/4 cm is a small-format landscape-oriented print. Its placement at position #40 follows the Pregnancy section cluster (#33–#41): Himmel (#33), Frank (#34), Rodger (#35), Lewis (#36), Erwitt (#37), Haga (#38), Álvarez Bravo (#39), Frank (#40 — this plate), Harrington (#41).
+
+**On the "Swiss" credit:** All seven Frank plates carry "Swiss" in the Master Checklist. Robert Frank had not yet naturalized as a US citizen in January 1955; the post-1955 naturalization year is reported in secondary literature as 1963 but is NOT verified against any Tier-1/2 source fetched this round. The canonical nationality form in `data/photographers.csv` is "Swiss-American"; the checklist credit "Swiss" reflects his 1955-era citizenship.
+
+## Subject and context
+
+Section 4 "Pregnancy" (plates #33–#41) precedes Section 5 "Childbirth" (#42–#44) in the exhibition's human life-cycle narrative arc. Frank's two Pregnancy plates (photo-0031 at #34 and this plate at #40) are both located in the USA, and both use small horizontal formats (12 × 17 cm and 13 × 16 1/4 cm respectively).
+
+The ICP archive page (`src-icp-frank-archive`, Tier-1, in-repo, read this session) states verbatim: *"Between 1950 and 1955 he worked freelance producing photojournalism and advertising photographs for LIFE, Look, Charm, Vogue, and others."* Both Pregnancy plates (photo-0031 and photo-0037) were therefore made during Frank's freelance period — before the Guggenheim Fellowship that funded *The Americans* road trip. The ICP page also states: *"Walker Evans, who became an important American advocate of Frank's photography. It was Evans who suggested that he apply for the Guggenheim Fellowship."* Steichen's selection of Frank for seven FoM plates represents Steichen as an early American institutional advocate of Frank's work.
+
+The Pregnancy section places Frank's second plate at #40, immediately before the section close (Harrington, Arctic, #41) and followed by the Childbirth section's three Wayne Miller plates (#42–#44). The Scriabin caption (Caption 4) installed under plate #44 — *"The universe resounds with the joyful cry I am."* — concludes the Pregnancy-Childbirth arc.
+
+Frank's positioning in the Pregnancy section is significant in the context of *The Americans* (first published in France 1957, US edition 1959): the ICP page states verbatim *"The Americans was one of the most revolutionary volumes in the history of photography."* The two Pregnancy plates represent Frank at the transitional moment before that revolution — engaged with the humanist documentary tradition that *The Americans* would subsequently critique.
+
+## Reception / analysis
+
+No plate-specific critical reception for checklist #40 has been located in any source consulted this round.
+
+The `src-wikipedia-frank-pointer` (Tier-3, in-repo, read this session) notes that seven of Frank's photographs appeared in the exhibition but does not specify which images were in the Pregnancy section. The Wikipedia summary paraphrase mentioned *"six laughing women in the window of the White Tower Hamburger Stand on Fourteenth Street, New York City"* as one of Frank's FoM images, but this is flagged in the source file as a paraphrase (not verbatim) and is not pinned to a specific checklist number. It cannot be attributed to plate #40 or plate #34 on the basis of that source.
+
+The critical-historical framing of Frank's FoM participation has been noted in scholarship on his career: the photographer who would produce the defining anti-humanist critique of American life contributed two Pregnancy-section plates to the exhibition most often cited as the apex of photographic humanism. This tension is well-documented in secondary literature but no specific source addressing plate #40 has been consulted this round.
+
+Roland Barthes ("The Great Family of Man," `src-barthes-1957`, Tier-2, in-repo) does not name Frank.
+
+## Perspective notes
+
+- **Curatorial (MoMA 1955):** Frank's seven plates span six sections of the exhibition (Pregnancy ×2, Food, Relationships, Aloneness and Compassion, Aspirations, Hard Times). The geographic distribution — USA ×3, Spain, Peru, Wales, England — reflects his early-1950s freelance assignments across multiple continents. Steichen's selection of Frank as a seven-plate contributor predates the Guggenheim Fellowship and marks Steichen as an early advocate of Frank's work.
+- **Critical / theoretical:** Plate #40 is the second of the two Frank Pregnancy plates and shares the small landscape format of plate #34. Together they form the exhibition's only double-plate sequence from a single Swiss photographer in the Pregnancy section. The biographical irony — Frank's FoM humanism vs. his subsequent *The Americans* anti-humanism — makes both plates recurring reference points in critical writing on the exhibition.
+
+## Open questions
+
+- The specific subjects of plates #34 and #40 (both Pregnancy section, USA) are not stated in the checklist and have not been confirmed from any Tier-1/2 source fetched this round.
+- Whether plate #40 is among the Clervaux Castle holdings (CNA, Luxembourg) was not verified this round.
+- Whether plate #40 corresponds to a known MoMA permanent-collection object ID was not verified this round.
+- The year of Frank's naturalization as an American citizen (reported in secondary literature as 1963) was NOT verified against any Tier-1/2 source fetched this round; the 1955 checklist credit "Swiss" is accepted as the contemporary designation.
+- The Wikipedia pointer paraphrase linking one of Frank's FoM plates to the "White Tower Hamburger Stand on Fourteenth Street" image is not pinned to plate #40 or plate #34 and was not further verified this round.


### PR DESCRIPTION
## Summary

- Adds 5 photograph research files for *The Family of Man* (closes #152)
- Covers plates #18 (Roy DeCarava, Lovers), #20 (Robert Doisneau, Lovers), #24 (Ernst Haas, Lovers), #29 (Wayne Miller, Marriage/Mexico), #40 (Robert Frank, Pregnancy)
- All plate-level claims verified verbatim from `src-moma-exh-0569-master-checklist` (Tier-1, in-repo, read this session)
- Biographical detail sourced from Tier-1 in-repo files: `src-icp-ernst-haas-archive`, `src-haas-estate-biography`, `src-icp-frank-archive` (all read this session)
- Unverifiable claims (day-month birth/death tokens for Doisneau/Haas/Miller; DeCarava Guggenheim/Sweet Flypaper; Miller curatorial role; Frank naturalization year) explicitly hedged per CLAUDE.md anti-confabulation protocol with `verified: false` and `NOT re-fetched` language
- Pre-commit `tvl-tech-bias-validator` caught one internal contradiction (photo-0015.md said "three plates" but listed four numbers); fixed before commit

## Source provenance

| File | Sources read this session |
|---|---|
| photo-0015 (DeCarava #18) | moma-exh-0569-master-checklist (T1), nyt-2009-decarava-obit (T3, not re-fetched) |
| photo-0017 (Doisneau #20) | moma-exh-0569-master-checklist (T1), lemonde-1994-doisneau-obit (T3, not re-fetched) |
| photo-0021 (Haas #24) | moma-exh-0569-master-checklist (T1), icp-ernst-haas-archive (T1), haas-estate-biography (T1), nyt-1986-haas-obit (T3, not re-fetched) |
| photo-0026 (Miller #29) | moma-exh-0569-master-checklist (T1), nyt-2013-wayne-miller-obit (T3, not re-fetched) |
| photo-0037 (Frank #40) | moma-exh-0569-master-checklist (T1), icp-frank-archive (T1), wikipedia-frank-pointer (T3) |

## Test plan

- [ ] Each file exists at `research/photographs/photo-XXXX.md`
- [ ] Each file's plate number, photographer name, dimensions, section, and country match the MoMA Master Checklist verbatim
- [ ] All unverified biographical tokens explicitly labeled `verified: false` / `NOT re-fetched` / `NOT verified against any Tier-1/2 source fetched this round`
- [ ] `scripts/check_injection_patterns.py` passes (no injection markers in new files)
- [ ] `tvl-tech-bias-validator` SHIP verdict (post-fix)

closes #152