### PR TITLE
Wire Wayne Miller portrait into bio — closes #166

### DIFF
--- a/research/photographers/wayne-miller.md
+++ b/research/photographers/wayne-miller.md
@@ -1,5 +1,8 @@
 # Wayne Miller (1918–2013)
 
+![Lt. Wayne Miller in his quarters aboard the USS Ticonderoga (CV-14), 1945](../../site/assets/images/miller-1945-uss-ticonderoga.jpg)
+*Lt. Wayne F. Miller in his quarters aboard the USS Ticonderoga (CV-14), 1945. U.S. Navy combat photograph, NARA item 520842 — public domain (work of the U.S. federal government). License: [miller-1945-uss-ticonderoga.license.json](../../site/assets/images/miller-1945-uss-ticonderoga.license.json).*
+
 Wayne F. Miller was an American photographer and Magnum member who served as Edward Steichen's curatorial assistant on *The Family of Man* (src-nyt-2013-wayne-miller-obit; src-magnum-photographer-bios). Born in Chicago on 19 September 1918 and trained under Steichen in the US Navy's Aviation Photographic Unit during the Second World War, Miller is represented in the MoMA Master Checklist by at least six prints in the first 47 plates alone (#22, #29, #42, #43, #44, #47) — more than any other contributor in that range (src-moma-exh-0569-master-checklist). He died in Orinda, California on 22 May 2013 (src-nyt-2013-wayne-miller-obit).
 
 ## Career


### PR DESCRIPTION
## Summary

- Portrait image `miller-1945-uss-ticonderoga.jpg` (PD-USGov, NARA item 520842) was shipped in PR #197 and is already in `site/gallery.md` and `site/index.md`
- This PR adds the missing portrait embed + caption to `research/photographers/wayne-miller.md`, the last acceptance criterion of issue #166
- No new license claims — the caption cites the existing `miller-1945-uss-ticonderoga.license.json` as the authoritative record (verified 2026-05-10)

## Changes

- `research/photographers/wayne-miller.md`: adds portrait image reference at top of bio with caption linking to `license.json`

## Test plan

- [x] `miller-1945-uss-ticonderoga.jpg` and `.license.json` exist in `site/assets/images/`
- [x] license.json fields: `license=PD-USGov`, `basis=public_domain`, `rights_holder=U.S. Department of the Navy / U.S. Government`, `source_archive=NARA item 520842`, `url_verified_at=2026-05-10`
- [x] tvl-tech-bias-validator: SHIP (all 5 checks PASS)
- [x] No content claims added beyond what the in-repo license.json records

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)